### PR TITLE
fix(gpu): default to Vulkan on Linux to avoid GLES/Wayland teardown segfault

### DIFF
--- a/crates/uzumaki/src/gpu.rs
+++ b/crates/uzumaki/src/gpu.rs
@@ -15,7 +15,8 @@ impl GpuContext {
         } else if cfg!(target_os = "macos") {
             wgpu::Backends::METAL
         } else {
-            wgpu::Backends::from_env().unwrap_or_default()
+            // GLES teardown segfaults on Wayland shutdown.
+            wgpu::Backends::from_env().unwrap_or(wgpu::Backends::VULKAN)
         };
 
         // WGPU_BACKEND=vulkan,dx12 (comma separated)


### PR DESCRIPTION
Closes #18.

On Linux, `Backends::from_env().unwrap_or_default()` falls back to `Backends::all()`, which instantiates the GLES/EGL backend alongside Vulkan. The adapter selects Vulkan and rendering works, but on shutdown `wgpu_hal::gles::egl::Inner::drop` calls into libEGL → libwayland-client after winit has already torn down the Wayland connection, causing a SIGSEGV.

Defaulting the Linux branch to `Backends::VULKAN` (while still honoring `WGPU_BACKEND` if set) fixes the crash.

## Test plan
- [x] Dev run: `uzumaki packages/playground/src/index.tsx` → close window via WM → 5/5 clean exits (0) on Arch + niri/Wayland, Intel ARL, Mesa EGL
- [x] Pack: `uzumaki build` in the playground → 206 MB standalone ELF → run → close → clean exit (0)
- [x] Adapter still selects `"Intel(R) Graphics (ARL)" - Vulkan` as before (confirmed via startup print)
- [x] `WGPU_BACKEND` env var still respected for override