### PR TITLE
refactor: element tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7786,7 +7786,6 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
- "serde",
  "version_check",
 ]
 
@@ -9274,7 +9273,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "slotmap",
+ "slab",
  "sys_traits",
  "taffy",
  "tokio",

--- a/crates/uzumaki/Cargo.toml
+++ b/crates/uzumaki/Cargo.toml
@@ -36,7 +36,7 @@ deno_resolver = "0.72.0"
 
 # Rendering
 cosmic-text = "0.18.2"
-slotmap = { version = "1.1.1", features = ["serde"] }
+slab = "0.4"
 taffy = "0.9.2"
 vello = "0.8.0"
 wgpu = "28.0.0"

--- a/crates/uzumaki/js/core.ts
+++ b/crates/uzumaki/js/core.ts
@@ -9,29 +9,29 @@ interface Core {
   }): number;
   requestClose(): void;
   requestRedraw(windowId: number): void;
-  getRootNodeId(windowId: number): any;
-  createElement(windowId: number, elementType: string): any;
-  createTextNode(windowId: number, text: string): any;
-  appendChild(windowId: number, parentId: any, childId: any): void;
+  getRootNodeId(windowId: number): NodeId;
+  createElement(windowId: number, elementType: string): NodeId;
+  createTextNode(windowId: number, text: string): NodeId;
+  appendChild(windowId: number, parentId: NodeId, childId: NodeId): void;
   insertBefore(
     windowId: number,
-    parentId: any,
-    childId: any,
-    beforeId: any,
+    parentId: NodeId,
+    childId: NodeId,
+    beforeId: NodeId,
   ): void;
-  removeChild(windowId: number, parentId: any, childId: any): void;
-  setText(windowId: number, nodeId: any, text: string): void;
+  removeChild(windowId: number, parentId: NodeId, childId: NodeId): void;
+  setText(windowId: number, nodeId: NodeId, text: string): void;
   resetDom(windowId: number): void;
   setLengthProp(
     windowId: number,
-    nodeId: any,
+    nodeId: NodeId,
     prop: number,
     value: number,
     unit: number,
   ): void;
   setColorProp(
     windowId: number,
-    nodeId: any,
+    nodeId: NodeId,
     prop: number,
     r: number,
     g: number,

--- a/crates/uzumaki/js/events.ts
+++ b/crates/uzumaki/js/events.ts
@@ -117,10 +117,6 @@ const NON_BUBBLING: Set<EventType> = new Set([
   EventType.WindowLoad,
 ]);
 
-function nodeKey(id: any): string {
-  return JSON.stringify(id);
-}
-
 function isMouseType(t: EventType): boolean {
   return t >= 0 && t <= 3;
 }
@@ -150,7 +146,7 @@ type NodeHandlers = Map<EventType, HandlerEntry[]>;
 
 export class EventManager {
   /** nodeKey -> EventType -> HandlerEntry[] */
-  private handlers = new Map<string, NodeHandlers>();
+  private handlers = new Map<number, NodeHandlers>();
 
   /** windowId (number) -> EventType -> HandlerEntry[] */
   private windowHandlers = new Map<number, Map<EventType, HandlerEntry[]>>();
@@ -161,7 +157,7 @@ export class EventManager {
     handler: Function,
     capture = false,
   ): void {
-    const key = nodeKey(nodeId);
+    const key = nodeId;
     let typeMap = this.handlers.get(key);
     if (!typeMap) {
       typeMap = new Map();
@@ -181,7 +177,7 @@ export class EventManager {
     handler: Function,
     capture = false,
   ): void {
-    const key = nodeKey(nodeId);
+    const key = nodeId;
     const typeMap = this.handlers.get(key);
     if (!typeMap) return;
     const entries = typeMap.get(eventType);
@@ -195,11 +191,11 @@ export class EventManager {
   }
 
   clearNode(nodeId: NodeId): void {
-    this.handlers.delete(nodeKey(nodeId));
+    this.handlers.delete(nodeId);
   }
 
   hasHandlers(nodeId: NodeId): boolean {
-    const typeMap = this.handlers.get(nodeKey(nodeId));
+    const typeMap = this.handlers.get(nodeId);
     return typeMap != null && typeMap.size > 0;
   }
 
@@ -224,7 +220,7 @@ export class EventManager {
   }
 
   clearHandlersByName(nodeId: NodeId, eventName: string): void {
-    const key = nodeKey(nodeId);
+    const key = nodeId;
     const typeMap = this.handlers.get(key);
     if (!typeMap) return;
     const t = EVENT_NAME_TO_TYPE[eventName];
@@ -297,7 +293,7 @@ export class EventManager {
   }
 
   private fireHandlers(
-    key: string,
+    key: number,
     type: EventType,
     event: UzumakiEvent,
     capturePhase: boolean,
@@ -489,7 +485,7 @@ export class EventManager {
     // Walk path in reverse (root → target) for capture
     for (let i = path.length - 1; i > 0 && !_stopped; i--) {
       event.currentTarget = path[i];
-      const res = this.fireHandlers(nodeKey(path[i]), type, event, true);
+      const res = this.fireHandlers(path[i], type, event, true);
       if (res.stopped) _stopped = true;
     }
 
@@ -498,7 +494,7 @@ export class EventManager {
       _eventPhase = EventPhase.Target;
       event.currentTarget = path[0];
       const res = this.fireHandlers(
-        nodeKey(path[0]),
+        path[0],
         type,
         event,
         false, // doesn't matter for target phase — fireHandlers fires all
@@ -513,7 +509,7 @@ export class EventManager {
       // Walk from parent of target up to root
       for (let i = 1; i < path.length && !_stopped; i++) {
         event.currentTarget = path[i];
-        const res = this.fireHandlers(nodeKey(path[i]), type, event, false);
+        const res = this.fireHandlers(path[i], type, event, false);
         if (res.stopped) _stopped = true;
       }
 

--- a/crates/uzumaki/js/index.ts
+++ b/crates/uzumaki/js/index.ts
@@ -57,11 +57,7 @@ const EVENT_TYPE_MAP: Record<string, EventType> = {
 ): boolean {
   // WindowLoad is a special event dispatched directly to window handlers
   if (event.type === 'windowLoad') {
-    eventManager.dispatchWindowEvent(
-      event.windowId,
-      EventType.WindowLoad,
-      event,
-    );
+    eventManager.dispatchWindowEvent(event.windowId, EventType.WindowLoad);
     return false;
   }
 

--- a/crates/uzumaki/js/react/reconciler.ts
+++ b/crates/uzumaki/js/react/reconciler.ts
@@ -6,6 +6,7 @@ import type { JSX } from './jsx/runtime';
 
 import core, { PropKey } from '../core';
 import { eventManager } from '../events';
+import type { NodeId } from '../types';
 import { Window } from '../window';
 
 const PROP_NAME_TO_KEY: Record<string, number> = {
@@ -690,7 +691,7 @@ class TextElement extends BaseElement<Record<string, any>> {
 
 type Container = {
   window: Window;
-  rootNodeId: any;
+  rootNodeId: NodeId;
 };
 
 function getWindowId(container: Container): number {

--- a/crates/uzumaki/js/types.ts
+++ b/crates/uzumaki/js/types.ts
@@ -1,4 +1,1 @@
-export type NodeId = {
-  version: number;
-  idx: number;
-};
+export type NodeId = number;

--- a/crates/uzumaki/src/element.rs
+++ b/crates/uzumaki/src/element.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use cosmic_text::Attrs;
-use slotmap::{SlotMap, new_key_type};
+use slab::Slab;
 use unicode_segmentation::UnicodeSegmentation;
 use vello::Scene;
 use vello::kurbo::{Affine, Rect, RoundedRect, RoundedRectRadii};
@@ -75,9 +75,7 @@ impl RangeProvider for DomRangeProvider {
 
 pub type InputState = BaseInputState<DomRangeProvider>;
 
-new_key_type! {
-    pub struct NodeId;
-}
+pub type NodeId = usize;
 
 pub struct ScrollState {
     pub scroll_offset_y: f32,
@@ -247,8 +245,8 @@ pub struct Node {
     pub selectable: Option<bool>,
 }
 
-pub struct Dom {
-    pub nodes: SlotMap<NodeId, Node>,
+pub struct ElementTree {
+    pub nodes: Slab<Node>,
     pub taffy: taffy::TaffyTree<NodeContext>,
     pub root: Option<NodeId>,
     /// Hitboxes registered during the last paint pass.
@@ -284,19 +282,19 @@ pub struct Dom {
 }
 
 // Safety:  We only access it from main thread
-unsafe impl Send for Dom {}
-unsafe impl Sync for Dom {}
+unsafe impl Send for ElementTree {}
+unsafe impl Sync for ElementTree {}
 
-impl Default for Dom {
+impl Default for ElementTree {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Dom {
+impl ElementTree {
     pub fn new() -> Self {
         Self {
-            nodes: SlotMap::with_key(),
+            nodes: Slab::new(),
             taffy: taffy::TaffyTree::new(),
             root: None,
             hitbox_store: HitboxStore::default(),
@@ -499,6 +497,59 @@ impl Dom {
         }
     }
 
+    /// Single source of truth for clearing stale NodeId references when a node
+    /// is about to be freed. With plain `usize` NodeIds (slab), any long-lived
+    /// field holding a removed id would silently retarget to whatever node
+    /// reuses the slot. Every removal path MUST funnel through here.
+    ///
+    /// When adding a new long-lived `NodeId` field to `Dom`, register it here.
+    fn on_node_removed(&mut self, id: NodeId) {
+        if self.focused_node == Some(id) {
+            self.focused_node = None;
+        }
+        if self.dragging_input == Some(id) {
+            self.dragging_input = None;
+        }
+        if self.dragging_view_selection == Some(id) {
+            self.dragging_view_selection = None;
+        }
+        if self.last_click_node == Some(id) {
+            self.last_click_node = None;
+            self.click_count = 0;
+            self.last_click_time = None;
+        }
+        if let Some(d) = &self.scroll_drag
+            && d.node_id == id
+        {
+            self.scroll_drag = None;
+        }
+        if let Some((nid, _)) = self.scroll_lock
+            && nid == id
+        {
+            self.scroll_lock = None;
+        }
+        if let Some(sel) = self.selection.get()
+            && sel.root == id
+        {
+            self.selection.clear();
+        }
+
+        self.hit_state.hovered_nodes.retain(|&n| n != id);
+        if self.hit_state.top_node == Some(id) {
+            self.hit_state.top_node = None;
+        }
+        if self.hit_state.active_node == Some(id) {
+            self.hit_state.active_node = None;
+        }
+
+        self.scroll_thumbs.retain(|t| t.node_id != id);
+        self.hitbox_store.retain_by_node(|n| n != id);
+
+        // Selectable text runs reference nodes as both roots and entries.
+        self.selectable_text_runs
+            .retain(|r| r.root_id != id && !r.entries.iter().any(|e| e.node_id == id));
+    }
+
     pub fn remove_child(&mut self, parent_id: NodeId, child_id: NodeId) {
         let parent_taffy = self.nodes[parent_id].taffy_node;
         let child_taffy = self.nodes[child_id].taffy_node;
@@ -531,10 +582,11 @@ impl Dom {
             }
         }
 
-        // Free taffy nodes + slotmap entries
+        // remove taffy and slab nodes
         for nid in to_remove {
             let tn = self.nodes[nid].taffy_node;
             let _ = self.taffy.remove(tn);
+            self.on_node_removed(nid);
             self.nodes.remove(nid);
         }
     }
@@ -593,20 +645,17 @@ impl Dom {
             let _ = self.taffy.remove_child(parent_taffy, tc);
         }
 
-        // Remove descendants from taffy + slotmap
+        // Remove descendants from taffy + slab; scrub stale NodeId references first.
         for nid in to_remove {
             let tn = self.nodes[nid].taffy_node;
             let _ = self.taffy.remove(tn);
+            self.on_node_removed(nid);
             self.nodes.remove(nid);
         }
 
         // Reset parent pointers
         self.nodes[parent_id].first_child = None;
         self.nodes[parent_id].last_child = None;
-
-        // Stale hitboxes reference removed nodes
-        self.hitbox_store.clear();
-        self.hit_state = HitTestState::default();
     }
 
     pub fn compute_layout(&mut self, width: f32, height: f32, text_renderer: &mut TextRenderer) {
@@ -1504,12 +1553,12 @@ fn available_as_option(space: taffy::AvailableSpace) -> Option<f32> {
 
 #[cfg(test)]
 mod tests {
-    use super::Dom;
+    use super::ElementTree;
     use crate::style::Bounds;
 
     #[test]
     fn refresh_hit_test_retargets_stationary_pointer_after_hitboxes_change() {
-        let mut dom = Dom::new();
+        let mut dom = ElementTree::new();
         let first = dom.create_view(Default::default());
         let second = dom.create_view(Default::default());
 

--- a/crates/uzumaki/src/event_dispatch.rs
+++ b/crates/uzumaki/src/event_dispatch.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use winit::keyboard::{Key, NamedKey};
 
 use crate::clipboard::SystemClipboard;
-use crate::element::{Dom, NodeId, ScrollDragState};
+use crate::element::{ElementTree, NodeId, ScrollDragState};
 use crate::input;
 use crate::selection::{DomSelection, SelectionRange};
 use crate::window::Window;
@@ -93,7 +93,7 @@ pub enum AppEvent {
 }
 
 pub fn handle_redraw(
-    dom: &mut Dom,
+    dom: &mut ElementTree,
     handle: &mut Window,
     device: &wgpu::Device,
     queue: &wgpu::Queue,
@@ -103,7 +103,7 @@ pub fn handle_redraw(
 
 /// Scroll the focused input so the cursor stays visible.
 /// Call this after any action that moves the cursor (key press, click, drag).
-pub fn scroll_input_to_cursor(dom: &mut Dom, handle: &mut Window) {
+pub fn scroll_input_to_cursor(dom: &mut ElementTree, handle: &mut Window) {
     let Some(focused_id) = dom.focused_node else {
         return;
     };
@@ -177,7 +177,7 @@ pub fn scroll_input_to_cursor(dom: &mut Dom, handle: &mut Window) {
 // ── Cursor moved ─────────────────────────────────────────────────────
 
 pub fn handle_cursor_moved(
-    dom: &mut Dom,
+    dom: &mut ElementTree,
     handle: &mut Window,
     position: winit::dpi::PhysicalPosition<f64>,
     mouse_buttons: u8,
@@ -324,7 +324,7 @@ pub fn handle_cursor_moved(
 /// Hit-test a mouse position against all text nodes in a textSelect run.
 /// Returns the flat grapheme index if a suitable text node is found.
 fn hit_text_in_run(
-    dom: &Dom,
+    dom: &ElementTree,
     text_renderer: &mut crate::text::TextRenderer,
     root_id: crate::element::NodeId,
     mx: f64,
@@ -382,7 +382,7 @@ fn point_to_rect_dist(px: f64, py: f64, bounds: &crate::style::Bounds) -> f64 {
 
 /// Find word boundaries around a flat grapheme index within a text run.
 fn word_boundaries_in_run(
-    dom: &Dom,
+    dom: &ElementTree,
     root_id: crate::element::NodeId,
     flat_idx: usize,
 ) -> (usize, usize) {
@@ -447,7 +447,7 @@ fn word_boundaries_in_run(
 // ── Mouse input ──────────────────────────────────────────────────────
 
 pub fn handle_mouse_input(
-    dom: &mut Dom,
+    dom: &mut ElementTree,
     handle: &mut Window,
     wid: u32,
     btn_state: winit::event::ElementState,
@@ -861,7 +861,7 @@ pub fn handle_mouse_input(
 
 /// Build the raw KeyDown/KeyUp event. Returns None for F5 (hot reload) or unmappable keys.
 pub fn build_key_event(
-    dom: &Dom,
+    dom: &ElementTree,
     wid: u32,
     key_event: &winit::event::KeyEvent,
     modifiers: u32,
@@ -906,7 +906,7 @@ pub fn build_key_event(
 /// event has been dispatched to JS (so preventDefault can suppress this).
 /// Returns (needs_redraw, events_to_dispatch).
 pub fn handle_key_for_input(
-    dom: &mut Dom,
+    dom: &mut ElementTree,
     handle: &mut Window,
     wid: u32,
     key_event: &winit::event::KeyEvent,
@@ -1009,7 +1009,7 @@ pub fn handle_key_for_input(
 /// Called after input-level processing, only when there's no focused input.
 /// Returns true if a redraw is needed.
 pub fn handle_key_for_view_selection(
-    dom: &mut Dom,
+    dom: &mut ElementTree,
     key_event: &winit::event::KeyEvent,
     modifiers: u32,
 ) -> bool {
@@ -1107,7 +1107,7 @@ pub enum ClipboardCommand {
 }
 
 /// Resolve the current clipboard target from DOM state.
-fn resolve_clipboard_target(dom: &Dom) -> Option<ClipboardTarget> {
+fn resolve_clipboard_target(dom: &ElementTree) -> Option<ClipboardTarget> {
     if let Some(focused_id) = dom.focused_node
         && let Some(node) = dom.nodes.get(focused_id)
         && node.behavior.as_input().is_some()
@@ -1125,7 +1125,7 @@ fn resolve_clipboard_target(dom: &Dom) -> Option<ClipboardTarget> {
 /// Detect whether a key event is a clipboard shortcut and build the corresponding
 /// command. Returns `None` if the key is not a clipboard shortcut.
 pub fn build_clipboard_command(
-    dom: &Dom,
+    dom: &ElementTree,
     key_event: &winit::event::KeyEvent,
     modifiers: u32,
     clipboard: &mut SystemClipboard,
@@ -1276,7 +1276,7 @@ pub fn clipboard_command_to_event(cmd: &ClipboardCommand, wid: u32) -> AppEvent 
 /// Apply the default clipboard action. Returns (needs_redraw, follow_up_events).
 pub fn apply_clipboard_command(
     cmd: ClipboardCommand,
-    dom: &mut Dom,
+    dom: &mut ElementTree,
     wid: u32,
     clipboard: &mut SystemClipboard,
 ) -> (bool, Vec<AppEvent>) {
@@ -1344,7 +1344,11 @@ pub fn apply_clipboard_command(
 }
 
 /// Find the previous word boundary from a flat grapheme index in a text select run.
-fn prev_word_boundary_in_run(dom: &Dom, root_id: crate::element::NodeId, flat_idx: usize) -> usize {
+fn prev_word_boundary_in_run(
+    dom: &ElementTree,
+    root_id: crate::element::NodeId,
+    flat_idx: usize,
+) -> usize {
     let Some(run) = dom
         .selectable_text_runs
         .iter()
@@ -1376,7 +1380,11 @@ fn prev_word_boundary_in_run(dom: &Dom, root_id: crate::element::NodeId, flat_id
 }
 
 /// Find the next word boundary from a flat grapheme index in a text select run.
-fn next_word_boundary_in_run(dom: &Dom, root_id: crate::element::NodeId, flat_idx: usize) -> usize {
+fn next_word_boundary_in_run(
+    dom: &ElementTree,
+    root_id: crate::element::NodeId,
+    flat_idx: usize,
+) -> usize {
     let Some(run) = dom
         .selectable_text_runs
         .iter()
@@ -1408,7 +1416,7 @@ fn next_word_boundary_in_run(dom: &Dom, root_id: crate::element::NodeId, flat_id
     i
 }
 
-pub fn handle_mouse_wheel(dom: &mut Dom, scroll_delta_y: f64) -> bool {
+pub fn handle_mouse_wheel(dom: &mut ElementTree, scroll_delta_y: f64) -> bool {
     let mut needs_redraw = false;
     let Some((mx, my)) = dom.hit_state.mouse_position else {
         return false;

--- a/crates/uzumaki/src/interactivity.rs
+++ b/crates/uzumaki/src/interactivity.rs
@@ -56,6 +56,12 @@ impl HitboxStore {
         self.next_id = 0;
     }
 
+    /// Drop any hitbox whose `node_id` no longer passes `keep`.
+    /// Used by Dom::on_node_removed to scrub stale references after a node is freed.
+    pub fn retain_by_node(&mut self, mut keep: impl FnMut(NodeId) -> bool) {
+        self.hitboxes.retain(|h| keep(h.node_id));
+    }
+
     /// Register a hitbox and return its ID.
     pub fn insert(&mut self, node_id: NodeId, bounds: Bounds) -> HitboxId {
         let id = HitboxId(self.next_id);

--- a/crates/uzumaki/src/lib.rs
+++ b/crates/uzumaki/src/lib.rs
@@ -41,7 +41,7 @@ use std::sync::Arc;
 use winit::event_loop::EventLoopProxy;
 use winit::{application::ApplicationHandler, event::WindowEvent, window::WindowId};
 
-use crate::element::{Dom, NodeId};
+use crate::element::{ElementTree, NodeId};
 use crate::gpu::GpuContext;
 use crate::prop_keys::PropKey;
 use crate::selection::{DomSelection, SelectionRange};
@@ -70,7 +70,7 @@ pub fn create_snapshot(
 }
 
 pub struct WindowEntry {
-    pub dom: Dom,
+    pub dom: ElementTree,
     pub handle: Option<window::Window>,
     pub rem_base: f32,
 }
@@ -161,7 +161,7 @@ pub fn op_create_window(
 
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let mut dom = Dom::new();
+        let mut dom = ElementTree::new();
         let root = dom.create_view(Style {
             display: Display::Flex,
             size: Size {
@@ -223,57 +223,55 @@ pub fn op_request_redraw(
     Ok(())
 }
 
-#[op2]
-#[serde]
-pub fn op_get_root_node_id(state: &mut OpState, #[smi] window_id: u32) -> serde_json::Value {
+#[op2(fast)]
+pub fn op_get_root_node_id(state: &mut OpState, #[smi] window_id: u32) -> u32 {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get(&window_id).expect("window not found");
-        serde_json::to_value(entry.dom.root.expect("no root node")).unwrap()
+        entry.dom.root.expect("no root node") as u32
     })
 }
 
-#[op2]
-#[serde]
+#[op2(fast)]
 pub fn op_create_element(
     state: &mut OpState,
     #[smi] window_id: u32,
     #[string] element_type: String,
-) -> serde_json::Value {
+) -> u32 {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
-        if element_type == "input" {
-            serde_json::to_value(entry.dom.create_input(Style::default())).unwrap()
+        let id = if element_type == "input" {
+            entry.dom.create_input(Style::default())
         } else {
-            serde_json::to_value(entry.dom.create_view(Style::default())).unwrap()
-        }
+            entry.dom.create_view(Style::default())
+        };
+        id as u32
     })
 }
 
-#[op2]
-#[serde]
+#[op2(fast)]
 pub fn op_create_text_node(
     state: &mut OpState,
     #[smi] window_id: u32,
     #[string] text: String,
-) -> serde_json::Value {
+) -> u32 {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
-        serde_json::to_value(entry.dom.create_text(text, Style::default())).unwrap()
+        entry.dom.create_text(text, Style::default()) as u32
     })
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_append_child(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] parent_id: serde_json::Value,
-    #[serde] child_id: serde_json::Value,
+    #[smi] parent_id: u32,
+    #[smi] child_id: u32,
 ) {
-    let pid = serde_json::from_value::<NodeId>(parent_id).unwrap();
-    let cid = serde_json::from_value::<NodeId>(child_id).unwrap();
+    let pid = parent_id as NodeId;
+    let cid = child_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -281,17 +279,17 @@ pub fn op_append_child(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_insert_before(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] parent_id: serde_json::Value,
-    #[serde] child_id: serde_json::Value,
-    #[serde] before_id: serde_json::Value,
+    #[smi] parent_id: u32,
+    #[smi] child_id: u32,
+    #[smi] before_id: u32,
 ) {
-    let pid = serde_json::from_value::<NodeId>(parent_id).unwrap();
-    let cid = serde_json::from_value::<NodeId>(child_id).unwrap();
-    let bid = serde_json::from_value::<NodeId>(before_id).unwrap();
+    let pid = parent_id as NodeId;
+    let cid = child_id as NodeId;
+    let bid = before_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -299,15 +297,15 @@ pub fn op_insert_before(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_remove_child(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] parent_id: serde_json::Value,
-    #[serde] child_id: serde_json::Value,
+    #[smi] parent_id: u32,
+    #[smi] child_id: u32,
 ) {
-    let pid = serde_json::from_value::<NodeId>(parent_id).unwrap();
-    let cid = serde_json::from_value::<NodeId>(child_id).unwrap();
+    let pid = parent_id as NodeId;
+    let cid = child_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -315,14 +313,14 @@ pub fn op_remove_child(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_text(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     #[string] text: String,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -341,16 +339,16 @@ pub fn op_reset_dom(state: &mut OpState, #[smi] window_id: u32) {
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_length_prop(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     #[smi] prop: u32,
     value: f64,
     #[smi] unit: u32,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let Ok(prop) = PropKey::try_from(prop) else {
         return;
     };
@@ -377,18 +375,18 @@ pub fn op_set_length_prop(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_color_prop(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     #[smi] prop: u32,
     #[smi] r: u32,
     #[smi] g: u32,
     #[smi] b: u32,
     #[smi] a: u32,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let Ok(prop) = PropKey::try_from(prop) else {
         return;
     };
@@ -440,15 +438,15 @@ pub fn op_set_color_prop(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_f32_prop(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     #[smi] prop: u32,
     value: f64,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let Ok(prop) = PropKey::try_from(prop) else {
         return;
     };
@@ -569,15 +567,15 @@ pub fn op_set_f32_prop(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_enum_prop(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     #[smi] prop: u32,
     #[smi] value: i32,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let Ok(prop) = PropKey::try_from(prop) else {
         return;
     };
@@ -634,14 +632,14 @@ pub fn op_set_enum_prop(
 
 // ── Input attribute ops ─────────────────────────────────────────────
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_input_value(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     #[string] value: String,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -658,9 +656,9 @@ pub fn op_set_input_value(
 pub fn op_get_input_value(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
 ) -> String {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get(&window_id).expect("window not found");
@@ -674,14 +672,14 @@ pub fn op_get_input_value(
     })
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_input_placeholder(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     #[string] placeholder: String,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -693,14 +691,14 @@ pub fn op_set_input_placeholder(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_input_disabled(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     disabled: bool,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -712,14 +710,14 @@ pub fn op_set_input_disabled(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_input_max_length(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     #[smi] max_length: i32,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -735,14 +733,14 @@ pub fn op_set_input_max_length(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_input_multiline(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     multiline: bool,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -754,14 +752,14 @@ pub fn op_set_input_multiline(
     });
 }
 
-#[op2]
+#[op2(fast)]
 pub fn op_set_input_secure(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
+    #[smi] node_id: u32,
     secure: bool,
 ) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -773,13 +771,9 @@ pub fn op_set_input_secure(
     });
 }
 
-#[op2]
-pub fn op_focus_input(
-    state: &mut OpState,
-    #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
-) {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+#[op2(fast)]
+pub fn op_focus_input(state: &mut OpState, #[smi] window_id: u32, #[smi] node_id: u32) {
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get_mut(&window_id).expect("window not found");
@@ -842,16 +836,16 @@ pub fn op_get_window_title(state: &mut OpState, #[smi] window_id: u32) -> Option
 pub fn op_get_ancestor_path(
     state: &mut OpState,
     #[smi] window_id: u32,
-    #[serde] node_id: serde_json::Value,
-) -> Vec<serde_json::Value> {
-    let nid = serde_json::from_value::<NodeId>(node_id).unwrap();
+    #[smi] node_id: u32,
+) -> Vec<u32> {
+    let nid = node_id as NodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get(&window_id).expect("window not found");
         let mut path = Vec::new();
         let mut current = Some(nid);
         while let Some(id) = current {
-            path.push(serde_json::to_value(id).unwrap());
+            path.push(id as u32);
             current = entry.dom.nodes.get(id).and_then(|n| n.parent);
         }
         path
@@ -863,6 +857,19 @@ pub fn op_get_ancestor_path(
 #[op2]
 #[serde]
 pub fn op_get_selection(state: &mut OpState, #[smi] window_id: u32) -> serde_json::Value {
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct SelectionState {
+        root_node_id: u32,
+        anchor_offset: usize,
+        active_offset: usize,
+        start: usize,
+        end: usize,
+        run_length: usize,
+        is_collapsed: bool,
+        text: String,
+    }
+
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let entry = s.windows.get(&window_id).expect("window not found");
@@ -872,17 +879,17 @@ pub fn op_get_selection(state: &mut OpState, #[smi] window_id: u32) -> serde_jso
         };
         let run_length = dom.selection_run_length().unwrap_or(0);
         let text = dom.selected_text();
-        // bro use a typed struct  TT
-        serde_json::json!({
-            "rootNodeId": serde_json::to_value(sel.root).unwrap(),
-            "anchorOffset": sel.anchor(),
-            "activeOffset": sel.active(),
-            "start": sel.start(),
-            "end": sel.end(),
-            "runLength": run_length,
-            "isCollapsed": sel.is_collapsed(),
-            "text": text,
+        serde_json::to_value(SelectionState {
+            root_node_id: sel.root as u32,
+            anchor_offset: sel.anchor(),
+            active_offset: sel.active(),
+            start: sel.start(),
+            end: sel.end(),
+            run_length,
+            is_collapsed: sel.is_collapsed(),
+            text,
         })
+        .unwrap()
     })
 }
 
@@ -923,7 +930,7 @@ pub fn op_write_clipboard_text(state: &mut OpState, #[string] text: String) -> b
     }
 }
 
-fn sync_taffy(dom: &mut Dom, node_id: NodeId) {
+fn sync_taffy(dom: &mut ElementTree, node_id: NodeId) {
     let node = &dom.nodes[node_id];
     let taffy_style = node.style.to_taffy();
     let tn = node.taffy_node;

--- a/crates/uzumaki/src/window.rs
+++ b/crates/uzumaki/src/window.rs
@@ -5,7 +5,7 @@ use vello::{AaSupport, RenderParams, RendererOptions, Scene};
 
 use winit::window::Window as WinitWindow;
 
-use crate::element::Dom;
+use crate::element::ElementTree;
 use crate::gpu::GpuContext;
 use crate::text::TextRenderer;
 
@@ -90,7 +90,7 @@ impl Window {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        dom: &mut Dom,
+        dom: &mut ElementTree,
     ) {
         if !self.valid_surface {
             return;

--- a/crates/uzumaki/tsconfig.json
+++ b/crates/uzumaki/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["js/**/*.ts", "js/**/*.tsx"]
+}


### PR DESCRIPTION
## Description
This PR switches node IDs to simple numeric handles and moves the internal tree storage to `slab`. It also renames `Dom` to `ElementTree` and updates the JS bridge to use numbers directly instead of serialized node ID objects.

The goal is to make hot paths cheaper. Using numeric IDs removes a bunch of serde overhead across the Rust/JS boundary, makes fast-op-friendly signatures easier. Since slab IDs can be reused, this also adds cleanup so removed nodes do not leave stale state behind.


## Checklist

- [x] I have run `cargo fmt` and `pnpm format`
- [x] I have run `cargo clippy --workspace -D warnings` and `pnpm lint` with no errors
- [x] I have manually tested my changes
- [x] This PR is focused on a single scope — no unrelated drive-by changes
- [x] If this PR uses AI-generated code, I have thoroughly reviewed and tested every line myself
