### PR TITLE
fix: handle missing window gracefully in DOM ops

### DIFF
--- a/crates/uzumaki/src/ops/dom.rs
+++ b/crates/uzumaki/src/ops/dom.rs
@@ -8,7 +8,9 @@ use crate::style::*;
 pub fn op_get_root_node_id(state: &mut OpState, #[smi] window_id: u32) -> u32 {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get(&window_id) else {
+            return 0;
+        };
         entry.dom.root.expect("no root node") as u32
     })
 }
@@ -21,7 +23,9 @@ pub fn op_create_element(
 ) -> u32 {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return 0;
+        };
         let id = if element_type == "input" {
             entry.dom.create_input(UzStyle::default())
         } else {
@@ -39,7 +43,9 @@ pub fn op_create_text_node(
 ) -> u32 {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return 0;
+        };
         entry.dom.create_text(text, UzStyle::default()) as u32
     })
 }
@@ -55,7 +61,9 @@ pub fn op_append_child(
     let cid = child_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         entry.dom.append_child(pid, cid);
     });
 }
@@ -73,7 +81,9 @@ pub fn op_insert_before(
     let bid = before_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         entry.dom.insert_before(pid, cid, bid);
     });
 }
@@ -89,7 +99,9 @@ pub fn op_remove_child(
     let cid = child_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         entry.dom.remove_child(pid, cid);
     });
 }
@@ -104,7 +116,9 @@ pub fn op_set_text(
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         entry.dom.set_text_content(nid, text);
     });
 }
@@ -130,7 +144,9 @@ pub fn op_set_input_value(
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
@@ -149,7 +165,9 @@ pub fn op_get_input_value(
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get(&window_id) else {
+            return String::new();
+        };
         entry
             .dom
             .nodes
@@ -170,7 +188,9 @@ pub fn op_set_input_placeholder(
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
@@ -189,7 +209,9 @@ pub fn op_set_input_disabled(
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
@@ -208,7 +230,9 @@ pub fn op_set_input_max_length(
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
@@ -231,7 +255,9 @@ pub fn op_set_input_multiline(
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
@@ -250,7 +276,9 @@ pub fn op_set_input_secure(
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
@@ -264,7 +292,9 @@ pub fn op_focus_input(state: &mut OpState, #[smi] window_id: u32, #[smi] node_id
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get_mut(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return;
+        };
         entry.dom.focus_input(nid);
     });
 }
@@ -279,7 +309,9 @@ pub fn op_get_ancestor_path(
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get(&window_id) else {
+            return Vec::new();
+        };
         let mut path = Vec::new();
         let mut current = Some(nid);
         while let Some(id) = current {
@@ -309,7 +341,9 @@ pub fn op_get_selection(state: &mut OpState, #[smi] window_id: u32) -> serde_jso
 
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get(&window_id) else {
+            return serde_json::Value::Null;
+        };
         let dom = &entry.dom;
         let Some(sel) = dom.get_selection() else {
             return serde_json::Value::Null;
@@ -338,7 +372,9 @@ pub fn op_get_selection(state: &mut OpState, #[smi] window_id: u32) -> serde_jso
 pub fn op_get_selected_text(state: &mut OpState, #[smi] window_id: u32) -> String {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        let entry = s.windows.get(&window_id).expect("window not found");
+        let Some(entry) = s.windows.get(&window_id) else {
+            return String::new();
+        };
         entry.dom.selected_text()
     })
 }

--- a/crates/uzumaki/src/ops/dom.rs
+++ b/crates/uzumaki/src/ops/dom.rs
@@ -2,16 +2,19 @@ use deno_core::*;
 
 use crate::app::{SharedAppState, with_state};
 use crate::element::UzNodeId;
-use crate::style::*;
+use crate::style::UzStyle;
 
 #[op2(fast)]
-pub fn op_get_root_node_id(state: &mut OpState, #[smi] window_id: u32) -> u32 {
+pub fn op_get_root_node_id(
+    state: &mut OpState,
+    #[smi] window_id: u32,
+) -> Result<u32, deno_error::JsErrorBox> {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get(&window_id) else {
-            return 0;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
-        entry.dom.root.expect("no root node") as u32
+        Ok(entry.dom.root.expect("no root node") as u32)
     })
 }
 
@@ -20,18 +23,18 @@ pub fn op_create_element(
     state: &mut OpState,
     #[smi] window_id: u32,
     #[string] element_type: String,
-) -> u32 {
+) -> Result<u32, deno_error::JsErrorBox> {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return 0;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         let id = if element_type == "input" {
             entry.dom.create_input(UzStyle::default())
         } else {
             entry.dom.create_view(UzStyle::default())
         };
-        id as u32
+        Ok(id as u32)
     })
 }
 
@@ -40,13 +43,13 @@ pub fn op_create_text_node(
     state: &mut OpState,
     #[smi] window_id: u32,
     #[string] text: String,
-) -> u32 {
+) -> Result<u32, deno_error::JsErrorBox> {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return 0;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
-        entry.dom.create_text(text, UzStyle::default()) as u32
+        Ok(entry.dom.create_text(text, UzStyle::default()) as u32)
     })
 }
 
@@ -56,16 +59,17 @@ pub fn op_append_child(
     #[smi] window_id: u32,
     #[smi] parent_id: u32,
     #[smi] child_id: u32,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let pid = parent_id as UzNodeId;
     let cid = child_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         entry.dom.append_child(pid, cid);
-    });
+        Ok(())
+    })
 }
 
 #[op2(fast)]
@@ -75,17 +79,18 @@ pub fn op_insert_before(
     #[smi] parent_id: u32,
     #[smi] child_id: u32,
     #[smi] before_id: u32,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let pid = parent_id as UzNodeId;
     let cid = child_id as UzNodeId;
     let bid = before_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         entry.dom.insert_before(pid, cid, bid);
-    });
+        Ok(())
+    })
 }
 
 #[op2(fast)]
@@ -94,16 +99,17 @@ pub fn op_remove_child(
     #[smi] window_id: u32,
     #[smi] parent_id: u32,
     #[smi] child_id: u32,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let pid = parent_id as UzNodeId;
     let cid = child_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         entry.dom.remove_child(pid, cid);
-    });
+        Ok(())
+    })
 }
 
 #[op2(fast)]
@@ -112,26 +118,32 @@ pub fn op_set_text(
     #[smi] window_id: u32,
     #[smi] node_id: u32,
     #[string] text: String,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         entry.dom.set_text_content(nid, text);
-    });
+        Ok(())
+    })
 }
 
 #[op2(fast)]
-pub fn op_reset_dom(state: &mut OpState, #[smi] window_id: u32) {
+pub fn op_reset_dom(
+    state: &mut OpState,
+    #[smi] window_id: u32,
+) -> Result<(), deno_error::JsErrorBox> {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
-        if let Some(entry) = s.windows.get_mut(&window_id) {
-            let root = entry.dom.root.expect("no root node");
-            entry.dom.clear_children(root);
-        }
-    });
+        let Some(entry) = s.windows.get_mut(&window_id) else {
+            return Err(deno_error::JsErrorBox::generic("window not found"));
+        };
+        let root = entry.dom.root.expect("no root node");
+        entry.dom.clear_children(root);
+        Ok(())
+    })
 }
 
 #[op2(fast)]
@@ -140,19 +152,20 @@ pub fn op_set_input_value(
     #[smi] window_id: u32,
     #[smi] node_id: u32,
     #[string] value: String,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
             is.set_value(value);
         }
-    });
+        Ok(())
+    })
 }
 
 #[op2]
@@ -161,20 +174,20 @@ pub fn op_get_input_value(
     state: &mut OpState,
     #[smi] window_id: u32,
     #[smi] node_id: u32,
-) -> String {
+) -> Result<String, deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get(&window_id) else {
-            return String::new();
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
-        entry
+        Ok(entry
             .dom
             .nodes
             .get(nid)
             .and_then(|node| node.as_text_input())
             .map(|is| is.model.text())
-            .unwrap_or_default()
+            .unwrap_or_default())
     })
 }
 
@@ -184,19 +197,20 @@ pub fn op_set_input_placeholder(
     #[smi] window_id: u32,
     #[smi] node_id: u32,
     #[string] placeholder: String,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
             is.placeholder = placeholder;
         }
-    });
+        Ok(())
+    })
 }
 
 #[op2(fast)]
@@ -205,19 +219,20 @@ pub fn op_set_input_disabled(
     #[smi] window_id: u32,
     #[smi] node_id: u32,
     disabled: bool,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
             is.disabled = disabled;
         }
-    });
+        Ok(())
+    })
 }
 
 #[op2(fast)]
@@ -226,12 +241,12 @@ pub fn op_set_input_max_length(
     #[smi] window_id: u32,
     #[smi] node_id: u32,
     #[smi] max_length: i32,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
@@ -242,7 +257,8 @@ pub fn op_set_input_max_length(
                 None
             };
         }
-    });
+        Ok(())
+    })
 }
 
 #[op2(fast)]
@@ -251,19 +267,20 @@ pub fn op_set_input_multiline(
     #[smi] window_id: u32,
     #[smi] node_id: u32,
     multiline: bool,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
             is.multiline = multiline;
         }
-    });
+        Ok(())
+    })
 }
 
 #[op2(fast)]
@@ -272,31 +289,37 @@ pub fn op_set_input_secure(
     #[smi] window_id: u32,
     #[smi] node_id: u32,
     secure: bool,
-) {
+) -> Result<(), deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
             is.secure = secure;
         }
-    });
+        Ok(())
+    })
 }
 
 #[op2(fast)]
-pub fn op_focus_input(state: &mut OpState, #[smi] window_id: u32, #[smi] node_id: u32) {
+pub fn op_focus_input(
+    state: &mut OpState,
+    #[smi] window_id: u32,
+    #[smi] node_id: u32,
+) -> Result<(), deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get_mut(&window_id) else {
-            return;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         entry.dom.focus_input(nid);
-    });
+        Ok(())
+    })
 }
 
 #[op2]
@@ -305,12 +328,12 @@ pub fn op_get_ancestor_path(
     state: &mut OpState,
     #[smi] window_id: u32,
     #[smi] node_id: u32,
-) -> Vec<u32> {
+) -> Result<Vec<u32>, deno_error::JsErrorBox> {
     let nid = node_id as UzNodeId;
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get(&window_id) else {
-            return Vec::new();
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         let mut path = Vec::new();
         let mut current = Some(nid);
@@ -318,14 +341,17 @@ pub fn op_get_ancestor_path(
             path.push(id as u32);
             current = entry.dom.nodes.get(id).and_then(|n| n.parent);
         }
-        path
+        Ok(path)
     })
 }
 
 // Selection
 #[op2]
 #[serde]
-pub fn op_get_selection(state: &mut OpState, #[smi] window_id: u32) -> serde_json::Value {
+pub fn op_get_selection(
+    state: &mut OpState,
+    #[smi] window_id: u32,
+) -> Result<serde_json::Value, deno_error::JsErrorBox> {
     #[derive(serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     struct SelectionState {
@@ -342,18 +368,18 @@ pub fn op_get_selection(state: &mut OpState, #[smi] window_id: u32) -> serde_jso
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get(&window_id) else {
-            return serde_json::Value::Null;
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
         let dom = &entry.dom;
         let Some(sel) = dom.get_selection() else {
-            return serde_json::Value::Null;
+            return Ok(serde_json::Value::Null);
         };
         let Some(root) = sel.root else {
-            return serde_json::Value::Null;
+            return Ok(serde_json::Value::Null);
         };
         let run_length = dom.selection_run_length().unwrap_or(0);
         let text = dom.selected_text();
-        serde_json::to_value(SelectionState {
+        Ok(serde_json::to_value(SelectionState {
             root_node_id: root as u32,
             anchor_offset: sel.anchor(),
             active_offset: sel.active(),
@@ -363,18 +389,21 @@ pub fn op_get_selection(state: &mut OpState, #[smi] window_id: u32) -> serde_jso
             is_collapsed: sel.is_collapsed(),
             text,
         })
-        .unwrap()
+        .unwrap())
     })
 }
 
 #[op2]
 #[string]
-pub fn op_get_selected_text(state: &mut OpState, #[smi] window_id: u32) -> String {
+pub fn op_get_selected_text(
+    state: &mut OpState,
+    #[smi] window_id: u32,
+) -> Result<String, deno_error::JsErrorBox> {
     let app_state = state.borrow::<SharedAppState>().clone();
     with_state(&app_state, |s| {
         let Some(entry) = s.windows.get(&window_id) else {
-            return String::new();
+            return Err(deno_error::JsErrorBox::generic("window not found"));
         };
-        entry.dom.selected_text()
+        Ok(entry.dom.selected_text())
     })
 }


### PR DESCRIPTION
## Description

Fix occasional panic during application shutdown caused by missing window references in DOM operations.

**Root cause**
A race condition between the JS runtime and window cleanup allowed DOM operations in `crates/uzumaki/src/ops/dom.rs` to execute after the window had already been destroyed. These operations used `.expect("window not found")`, triggering a panic instead of handling the condition.

**Changes**
Replaced `.expect("window not found")` with explicit error handling across all affected functions in `dom.rs`.
DOM operations now return early when the window is no longer available.

After this change, we should expect no more occasional panicking during shutdown.

## Checklist

- [x] I have run `cargo fmt` and `pnpm format`
- [x] I have run `cargo clippy --workspace -D warnings` and `pnpm lint` with no errors
- [x] I have manually tested my changes
- [x] This PR is focused on a single scope — no unrelated drive-by changes
- [x] If this PR uses AI-generated code, I have thoroughly reviewed and tested every line myself
