### PR TITLE
fix: js timers while winit event loop is idle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9248,6 +9248,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "ureq",
  "uzumaki_runtime",
  "winapi",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,3 +24,4 @@ zip.workspace = true
 tempfile.workspace = true
 libsui = "0.14"
 dirs.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "time", "net"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -46,7 +46,12 @@ fn main() {
 }
 
 fn run_launch_mode(mode: standalone::LaunchMode) {
-    let tokio_runtime = uzumaki_runtime::deno_runtime::tokio_util::create_basic_runtime();
+    let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("failed to create tokio runtime");
     let entry = mode.entry_path().to_path_buf();
     let app_root = mode.app_root().to_path_buf();
     let mut app = tokio_runtime.block_on(async {

--- a/crates/uzumaki/src/app.rs
+++ b/crates/uzumaki/src/app.rs
@@ -3,9 +3,12 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
 
 use anyhow::Result;
-use deno_core::v8;
+use deno_core::futures::task::{ArcWake, waker};
+use deno_core::{PollEventLoopOptions, v8};
 use deno_resolver::npm::{
     ByonmNpmResolverCreateOptions, CreateInNpmPkgCheckerOptions, DenoInNpmPackageChecker,
     NpmResolver, NpmResolverCreateOptions,
@@ -103,7 +106,31 @@ pub(crate) enum UserEvent {
     RequestRedraw {
         id: u32,
     },
+    WakeJs,
     Quit,
+}
+
+struct JsWakeHandle {
+    proxy: winit::event_loop::EventLoopProxy<UserEvent>,
+    queued: AtomicBool,
+}
+
+impl JsWakeHandle {
+    fn wake(&self) {
+        if !self.queued.swap(true, Ordering::SeqCst) {
+            let _ = self.proxy.send_event(UserEvent::WakeJs);
+        }
+    }
+
+    fn clear(&self) {
+        self.queued.store(false, Ordering::SeqCst);
+    }
+}
+
+impl ArcWake for JsWakeHandle {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        JsWakeHandle::wake(arc_self.as_ref());
+    }
 }
 
 pub struct Application {
@@ -116,6 +143,7 @@ pub struct Application {
     module_loaded: bool,
     pub tokio_runtime: Option<tokio::runtime::Runtime>,
     global_app_event_dispatch_fn: Option<v8::Global<v8::Function>>,
+    js_wake_handle: Arc<JsWakeHandle>,
 }
 
 impl Application {
@@ -230,6 +258,11 @@ impl Application {
 
         let event_loop: winit::event_loop::EventLoop<UserEvent> =
             winit::event_loop::EventLoop::with_user_event().build()?;
+        let event_loop_proxy = event_loop.create_proxy();
+        let js_wake_handle = Arc::new(JsWakeHandle {
+            proxy: event_loop_proxy.clone(),
+            queued: AtomicBool::new(false),
+        });
 
         // Create GPU context
         let gpu = pollster::block_on(GpuContext::new()).expect("Failed to create GPU context");
@@ -251,7 +284,7 @@ impl Application {
             let op_state = worker.js_runtime.op_state();
             let mut borrow = op_state.borrow_mut();
             borrow.put(app_state.clone());
-            borrow.put(event_loop.create_proxy());
+            borrow.put(event_loop_proxy);
         }
 
         Ok(Self {
@@ -263,6 +296,7 @@ impl Application {
             module_loaded: false,
             tokio_runtime: None,
             global_app_event_dispatch_fn: None,
+            js_wake_handle,
         })
     }
 
@@ -275,19 +309,23 @@ impl Application {
         Ok(())
     }
 
-    fn tick_js(&mut self) {
+    fn pump_js(&mut self) {
+        let wake_handle = self.js_wake_handle.clone();
+        wake_handle.clear();
+
         let rt = self.tokio_runtime.as_ref().unwrap();
-        rt.block_on(async {
-            tokio::select! {
-                biased;
-                result = self.worker.run_event_loop(false) => {
-                    if let Err(e) = result {
-                        eprintln!("JS error: {e}");
-                    }
-                }
-                _ = tokio::task::yield_now() => {}
-            }
-        });
+        let _guard = rt.enter();
+        let waker = waker(wake_handle);
+        let mut cx = Context::from_waker(&waker);
+
+        match self
+            .worker
+            .js_runtime
+            .poll_event_loop(&mut cx, PollEventLoopOptions::default())
+        {
+            Poll::Ready(Ok(())) | Poll::Pending => {}
+            Poll::Ready(Err(e)) => eprintln!("JS error: {e}"),
+        }
     }
 
     fn load_main_module(&mut self) {
@@ -298,7 +336,7 @@ impl Application {
         rt.block_on(async {
             self.worker.execute_main_module(&specifier).await.unwrap();
         });
-        self.tick_js();
+        self.pump_js();
     }
 
     fn ensure_dispatch_fn(&mut self) -> Result<()> {
@@ -380,7 +418,7 @@ impl ApplicationHandler<UserEvent> for Application {
     }
 
     fn about_to_wait(&mut self, _event_loop: &winit::event_loop::ActiveEventLoop) {
-        self.tick_js();
+        self.pump_js();
     }
 
     fn user_event(&mut self, event_loop: &winit::event_loop::ActiveEventLoop, event: UserEvent) {
@@ -448,6 +486,10 @@ impl ApplicationHandler<UserEvent> for Application {
                 {
                     handle.winit_window.request_redraw();
                 }
+            }
+            UserEvent::WakeJs => {
+                self.js_wake_handle.clear();
+                self.pump_js();
             }
             UserEvent::Quit => {
                 let mut state = self.app_state.borrow_mut();

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -3,8 +3,8 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "uzumaki-ui": "workspace:*",
-    "react": "^19.2.4"
+    "react": "^19.2.4",
+    "uzumaki-ui": "workspace:*"
   },
   "scripts": {
     "dev": "cargo r -p uzumaki --release -- src/index.tsx",
@@ -13,6 +13,7 @@
     "preview": "cargo r -p uzumaki --release -- dist/index.js"
   },
   "devDependencies": {
+    "@types/node": "^25.6.0",
     "@types/react": "^19.2.14"
   },
   "peerDependencies": {

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -6,6 +6,7 @@ import { App as DashboardApp } from './app';
 import { Button } from './button';
 import { App as CounterApp } from './counter';
 import { ACCENT_ORANGE, BASE_BG, BORDER, PANEL, SUBTEXT } from './styles';
+import { Timer } from './timer';
 
 const window = new Window('main', {
   width: 1200,
@@ -17,12 +18,12 @@ window.on('click', (_ev) => {
   // console.log('Click window');
 });
 
-type Examples = 'counter' | 'dashboard';
-
-const exampleMap: Record<Examples, React.ReactNode> = {
+const exampleMap = {
   counter: <CounterApp />,
   dashboard: <DashboardApp />,
-};
+  timer: <Timer />,
+} as const;
+type Examples = keyof typeof exampleMap;
 
 function Playground() {
   const [example, setExample] = useState<Examples | null>('dashboard');
@@ -41,8 +42,9 @@ function Playground() {
       >
         <text fontSize={24}>Select an example:</text>
         <view display="flex" flexDir="col" gap="16">
-          <Button onClick={() => setExample('counter')}>Counter</Button>
           <Button onClick={() => setExample('dashboard')}>Dashboard</Button>
+          <Button onClick={() => setExample('counter')}>Counter</Button>
+          <Button onClick={() => setExample('timer')}>Timer</Button>
         </view>
       </view>
     );

--- a/packages/playground/src/timer.tsx
+++ b/packages/playground/src/timer.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function Timer() {
+  const interval = useRef<NodeJS.Timeout | undefined>();
+
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    interval.current = setInterval(() => {
+      setCount((prev) => prev + 1);
+    }, 500);
+    return () => {
+      clearInterval(interval.current);
+    };
+  }, []);
+  return (
+    <view h="full" w="full" flex items="center" justify="center" bg="#181818">
+      Count {count}
+    </view>
+  );
+}

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -3,6 +3,7 @@
     // Environment setup & latest features
     "lib": ["ESNext"],
     "target": "ESNext",
+    "types": ["node"],
     "module": "Preserve",
     "moduleDetection": "force",
     "jsx": "react-jsx",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.38.3
-        version: 0.38.3(astro@6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))
+        version: 0.38.3(astro@6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))
       astro:
         specifier: ^6.0.1
-        version: 6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
+        version: 6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
       sharp:
         specifier: ^0.34.2
         version: 0.34.5
@@ -66,6 +66,9 @@ importers:
         specifier: workspace:*
         version: link:../../crates/uzumaki
     devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -500,7 +503,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution:
@@ -509,7 +511,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution:
@@ -518,7 +519,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution:
@@ -527,7 +527,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution:
@@ -536,7 +535,6 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution:
@@ -545,7 +543,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution:
@@ -554,7 +551,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution:
@@ -563,7 +559,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution:
@@ -573,7 +568,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution:
@@ -583,7 +577,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution:
@@ -593,7 +586,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution:
@@ -603,7 +595,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution:
@@ -613,7 +604,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution:
@@ -623,7 +613,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution:
@@ -633,7 +622,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution:
@@ -643,7 +631,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution:
@@ -769,7 +756,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.59.0':
     resolution:
@@ -779,7 +765,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.59.0':
     resolution:
@@ -789,7 +774,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.59.0':
     resolution:
@@ -799,7 +783,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.59.0':
     resolution:
@@ -809,7 +792,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.59.0':
     resolution:
@@ -819,7 +801,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.59.0':
     resolution:
@@ -829,7 +810,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.59.0':
     resolution:
@@ -839,7 +819,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.59.0':
     resolution:
@@ -1006,7 +985,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution:
@@ -1015,7 +993,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution:
@@ -1024,7 +1001,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution:
@@ -1033,7 +1009,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution:
@@ -1042,7 +1017,6 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution:
@@ -1051,7 +1025,6 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution:
@@ -1060,7 +1033,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution:
@@ -1069,7 +1041,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution:
@@ -1078,7 +1049,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution:
@@ -1087,7 +1057,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution:
@@ -1096,7 +1065,6 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution:
@@ -1105,7 +1073,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution:
@@ -1114,7 +1081,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution:
@@ -1325,6 +1291,12 @@ packages:
     resolution:
       {
         integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==,
+      }
+
+  '@types/node@25.6.0':
+    resolution:
+      {
+        integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==,
       }
 
   '@types/react-reconciler@0.33.0':
@@ -3331,6 +3303,12 @@ packages:
         integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
       }
 
+  undici-types@7.19.2:
+    resolution:
+      {
+        integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==,
+      }
+
   unified@11.0.5:
     resolution:
       {
@@ -3639,12 +3617,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.3(astro@6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))':
+  '@astrojs/mdx@5.0.3(astro@6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -3668,17 +3646,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.38.3(astro@6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))':
+  '@astrojs/starlight@0.38.3(astro@6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/mdx': 5.0.3(astro@6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))
+      '@astrojs/mdx': 5.0.3(astro@6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
-      astro-expressive-code: 0.41.7(astro@6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))
+      astro: 6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
+      astro-expressive-code: 0.41.7(astro@6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -4259,6 +4237,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/react-reconciler@0.33.0(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -4306,12 +4288,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)):
+  astro-expressive-code@0.41.7(astro@6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      astro: 6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
       rehype-expressive-code: 0.41.7
 
-  astro@6.1.6(@types/node@25.3.5)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3):
+  astro@6.1.6(@types/node@25.6.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
@@ -4362,8 +4344,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.2(@types/node@25.3.5)(yaml@2.8.3)
-      vitefu: 1.1.3(vite@7.3.2(@types/node@25.3.5)(yaml@2.8.3))
+      vite: 7.3.2(@types/node@25.6.0)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@7.3.2(@types/node@25.6.0)(yaml@2.8.3))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -5958,6 +5940,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici-types@7.19.2: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -6048,7 +6032,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.2(@types/node@25.3.5)(yaml@2.8.3):
+  vite@7.3.2(@types/node@25.6.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6057,13 +6041,13 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.3.5
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       yaml: 2.8.3
 
-  vitefu@1.1.3(vite@7.3.2(@types/node@25.3.5)(yaml@2.8.3)):
+  vitefu@1.1.3(vite@7.3.2(@types/node@25.6.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.3.5)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@25.6.0)(yaml@2.8.3)
 
   web-namespaces@2.0.1: {}
 


### PR DESCRIPTION
## Description

This fixes JS timers not firing while the `winit` event loop is idle.

Previously, `setTimeout`/`setInterval` callbacks only ran when some other window event woke the app, because the host used a current-thread Tokio runtime and the JS event loop wasn’t being woken independently. This change moves the host to a small multi-thread Tokio runtime and adds a wake bridge from Deno’s JS event loop back into `winit` using `EventLoopProxy`, so timer callbacks can run even when the UI is otherwise idle.


## Checklist

- [x] I have run `cargo fmt` and `pnpm format`
- [x] I have run `cargo clippy --workspace -D warnings` and `pnpm lint` with no errors
- [x] I have manually tested my changes
- [x] This PR is focused on a single scope — no unrelated drive-by changes
- [x] If this PR uses AI-generated code, I have thoroughly reviewed and tested every line myself
