### PR TITLE
feat: replace cosmic-text with parley for text rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,30 +1201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-text"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe782a9e7520cc7de2232c957a47f99d3a35e855552677d07a557bc1a3b66ed"
-dependencies = [
- "bitflags 2.11.0",
- "fontdb",
- "harfrust",
- "linebender_resource_handle",
- "log",
- "rangemap",
- "rustc-hash 2.1.1",
- "self_cell",
- "skrifa 0.40.0",
- "smol_str 0.3.6",
- "swash",
- "sys-locale",
- "unicode-bidi",
- "unicode-linebreak",
- "unicode-script",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "cpubits"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,15 +3642,6 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "font-types"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e4d2d0cf79d38430cc9dc9aadec84774bff2e1ba30ae2bf6c16cfce9385a23"
@@ -3683,26 +3650,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "fontconfig-parser"
-version = "0.5.8"
+name = "fontique"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+checksum = "23358480a54a886d51b306718d5ca743fdfe238e5df38ef650f4e72f29c5d9e9"
 dependencies = [
- "roxmltree",
-]
-
-[[package]]
-name = "fontdb"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
-dependencies = [
- "fontconfig-parser",
- "log",
+ "hashbrown 0.16.1",
+ "linebender_resource_handle",
  "memmap2",
- "slotmap",
- "tinyvec",
- "ttf-parser",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "parlance",
+ "read-fonts",
+ "roxmltree",
+ "smallvec",
+ "windows",
+ "windows-core",
+ "yeslogic-fontconfig-sys",
 ]
 
 [[package]]
@@ -4171,7 +4137,7 @@ dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "core_maths",
- "read-fonts 0.37.0",
+ "read-fonts",
  "smallvec",
 ]
 
@@ -4689,6 +4655,27 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a807a7488f3f758629ae86d99d9d30dce24da2fb2945d74c80a4f4a62c71db73"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebbb7321d9e21d25f5660366cb6c08201d0175898a3a6f7a41ee9685af21c80"
 
 [[package]]
 name = "id-arena"
@@ -5919,6 +5906,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6348,6 +6345,39 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parlance"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+
+[[package]]
+name = "parley"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c00ec192e1a402861526eff91a4b4690a2e5a17a4ae2deb772d72b49daf868"
+dependencies = [
+ "fontique",
+ "harfrust",
+ "hashbrown 0.16.1",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
+ "linebender_resource_handle",
+ "parlance",
+ "parley_data",
+ "skrifa",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232313eddc02ac27f015e8f8eeb7facce8a896116df7e3eda1bfd9f600a9a39d"
+dependencies = [
+ "icu_properties",
 ]
 
 [[package]]
@@ -6915,12 +6945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
-name = "rangemap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
-
-[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6948,23 +6972,13 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
-dependencies = [
- "bytemuck",
- "font-types 0.10.1",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
  "core_maths",
- "font-types 0.11.0",
+ "font-types",
 ]
 
 [[package]]
@@ -7146,9 +7160,12 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "rsa"
@@ -7512,12 +7529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "self_cell"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
-
-[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7756,22 +7767,12 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skrifa"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
-dependencies = [
- "bytemuck",
- "read-fonts 0.35.0",
-]
-
-[[package]]
-name = "skrifa"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
- "read-fonts 0.37.0",
+ "read-fonts",
 ]
 
 [[package]]
@@ -7851,12 +7852,6 @@ checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "smol_str"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 
 [[package]]
 name = "socket2"
@@ -8032,17 +8027,6 @@ name = "svg_fmt"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
-
-[[package]]
-name = "swash"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
-dependencies = [
- "skrifa 0.37.0",
- "yazi",
- "zeno",
-]
 
 [[package]]
 name = "swc_allocator"
@@ -8485,15 +8469,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sys-locale"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -9055,9 +9030,6 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-dependencies = [
- "core_maths",
-]
 
 [[package]]
 name = "twox-hash"
@@ -9078,12 +9050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9094,18 +9060,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-script"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
@@ -9262,13 +9216,13 @@ dependencies = [
  "anyhow",
  "arboard",
  "async-trait",
- "cosmic-text",
  "deno_ast",
  "deno_core",
  "deno_error",
  "deno_resolver",
  "deno_runtime",
  "node_resolver",
+ "parley",
  "pollster",
  "refineable",
  "rustls",
@@ -9346,7 +9300,7 @@ dependencies = [
  "log",
  "peniko",
  "png",
- "skrifa 0.40.0",
+ "skrifa",
  "static_assertions",
  "thiserror 2.0.18",
  "vello_encoding",
@@ -9363,7 +9317,7 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko",
- "skrifa 0.40.0",
+ "skrifa",
  "smallvec",
 ]
 
@@ -10410,7 +10364,7 @@ dependencies = [
  "rustix 0.38.44",
  "sctk-adwaita",
  "smithay-client-toolkit",
- "smol_str 0.2.2",
+ "smol_str",
  "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
@@ -10650,10 +10604,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
-name = "yazi"
-version = "0.2.1"
+name = "yeslogic-fontconfig-sys"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "yoke"
@@ -10701,12 +10660,6 @@ dependencies = [
  "syn 2.0.117",
  "synstructure 0.13.2",
 ]
-
-[[package]]
-name = "zeno"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/crates/uzumaki/Cargo.toml
+++ b/crates/uzumaki/Cargo.toml
@@ -36,7 +36,7 @@ node_resolver = "0.79.0"
 deno_resolver = "0.72.0"
 
 # Rendering
-cosmic-text = "0.18.2"
+parley = "0.8.0"
 slab = "0.4"
 taffy = "0.9.2"
 vello = "0.8.0"

--- a/crates/uzumaki/src/app.rs
+++ b/crates/uzumaki/src/app.rs
@@ -810,33 +810,31 @@ impl ApplicationHandler<UserEvent> for Application {
                     }
                     Ime::Preedit(text, cursor) => {
                         let mut state = self.app_state.borrow_mut();
-                        if let Some(entry) = state.windows.get_mut(&wid) {
-                            if let Some(fid) = entry.dom.focused_node
-                                && let Some(node) = entry.dom.nodes.get_mut(fid)
-                                && let Some(is) = node.as_text_input_mut()
-                            {
-                                is.set_preedit(text.clone(), cursor);
-                                if let Some(handle) = entry.handle.as_mut() {
-                                    event_dispatch::update_ime_cursor_area(&mut entry.dom, handle);
-                                }
-                                needs_redraw = true;
+                        if let Some(entry) = state.windows.get_mut(&wid)
+                            && let Some(fid) = entry.dom.focused_node
+                            && let Some(node) = entry.dom.nodes.get_mut(fid)
+                            && let Some(is) = node.as_text_input_mut()
+                        {
+                            is.set_preedit(text.clone(), cursor);
+                            if let Some(handle) = entry.handle.as_mut() {
+                                event_dispatch::update_ime_cursor_area(&mut entry.dom, handle);
                             }
+                            needs_redraw = true;
                         }
                     }
                     Ime::Enabled => {}
                     Ime::Disabled => {
                         let mut state = self.app_state.borrow_mut();
-                        if let Some(entry) = state.windows.get_mut(&wid) {
-                            if let Some(fid) = entry.dom.focused_node
-                                && let Some(node) = entry.dom.nodes.get_mut(fid)
-                                && let Some(is) = node.as_text_input_mut()
-                            {
-                                is.clear_preedit();
-                                if let Some(handle) = entry.handle.as_mut() {
-                                    event_dispatch::update_ime_cursor_area(&mut entry.dom, handle);
-                                }
-                                needs_redraw = true;
+                        if let Some(entry) = state.windows.get_mut(&wid)
+                            && let Some(fid) = entry.dom.focused_node
+                            && let Some(node) = entry.dom.nodes.get_mut(fid)
+                            && let Some(is) = node.as_text_input_mut()
+                        {
+                            is.clear_preedit();
+                            if let Some(handle) = entry.handle.as_mut() {
+                                event_dispatch::update_ime_cursor_area(&mut entry.dom, handle);
                             }
+                            needs_redraw = true;
                         }
                     }
                 }

--- a/crates/uzumaki/src/app.rs
+++ b/crates/uzumaki/src/app.rs
@@ -655,12 +655,19 @@ impl ApplicationHandler<UserEvent> for Application {
                                     } = *state;
                                     if let Some(entry) = windows.get_mut(&wid) {
                                         let mut cb = clipboard.borrow_mut();
-                                        event_dispatch::apply_clipboard_command(
-                                            cmd,
-                                            &mut entry.dom,
-                                            wid,
-                                            &mut cb,
-                                        )
+                                        let tr =
+                                            entry.handle.as_mut().map(|h| &mut h.text_renderer);
+                                        if let Some(text_renderer) = tr {
+                                            event_dispatch::apply_clipboard_command(
+                                                cmd,
+                                                &mut entry.dom,
+                                                wid,
+                                                &mut cb,
+                                                text_renderer,
+                                            )
+                                        } else {
+                                            (false, Vec::new())
+                                        }
                                     } else {
                                         (false, Vec::new())
                                     }
@@ -763,12 +770,76 @@ impl ApplicationHandler<UserEvent> for Application {
                     {
                         is.reset_blink();
                     }
+                    if focused && let Some(handle) = entry.handle.as_mut() {
+                        event_dispatch::update_ime_cursor_area(&mut entry.dom, handle);
+                    }
                     needs_redraw = true;
                 }
             }
-            WindowEvent::Ime(_ime) => {
-                // todo (aadi): do this next
-                // println!("IME EVENT: {:#?}", ime);
+            WindowEvent::Ime(ime) => {
+                use winit::event::Ime;
+                match ime {
+                    Ime::Commit(text) => {
+                        let input_events = {
+                            let mut state = self.app_state.borrow_mut();
+                            state.windows.get_mut(&wid).and_then(|entry| {
+                                let handle = entry.handle.as_mut()?;
+                                let fid = entry.dom.focused_node?;
+                                let node = entry.dom.nodes.get_mut(fid)?;
+                                let is = node.as_text_input_mut()?;
+                                let _edit = is.commit_ime_text(&text, &mut handle.text_renderer)?;
+                                let value = is.text();
+                                event_dispatch::update_ime_cursor_area(&mut entry.dom, handle);
+                                needs_redraw = true;
+                                Some(vec![event_dispatch::AppEvent::Input(
+                                    event_dispatch::InputEventData {
+                                        window_id: wid,
+                                        node_id: fid,
+                                        value,
+                                        input_type: "insertCompositionText".to_string(),
+                                        data: Some(text.clone()),
+                                    },
+                                )])
+                            })
+                        };
+                        if let Some(events) = input_events {
+                            for event in events {
+                                self.dispatch_event_to_js(&event);
+                            }
+                        }
+                    }
+                    Ime::Preedit(text, cursor) => {
+                        let mut state = self.app_state.borrow_mut();
+                        if let Some(entry) = state.windows.get_mut(&wid) {
+                            if let Some(fid) = entry.dom.focused_node
+                                && let Some(node) = entry.dom.nodes.get_mut(fid)
+                                && let Some(is) = node.as_text_input_mut()
+                            {
+                                is.set_preedit(text.clone(), cursor);
+                                if let Some(handle) = entry.handle.as_mut() {
+                                    event_dispatch::update_ime_cursor_area(&mut entry.dom, handle);
+                                }
+                                needs_redraw = true;
+                            }
+                        }
+                    }
+                    Ime::Enabled => {}
+                    Ime::Disabled => {
+                        let mut state = self.app_state.borrow_mut();
+                        if let Some(entry) = state.windows.get_mut(&wid) {
+                            if let Some(fid) = entry.dom.focused_node
+                                && let Some(node) = entry.dom.nodes.get_mut(fid)
+                                && let Some(is) = node.as_text_input_mut()
+                            {
+                                is.clear_preedit();
+                                if let Some(handle) = entry.handle.as_mut() {
+                                    event_dispatch::update_ime_cursor_area(&mut entry.dom, handle);
+                                }
+                                needs_redraw = true;
+                            }
+                        }
+                    }
+                }
             }
             WindowEvent::CursorLeft { .. } => {
                 let mut state = self.app_state.borrow_mut();
@@ -787,7 +858,8 @@ impl ApplicationHandler<UserEvent> for Application {
                     winit::event::MouseScrollDelta::PixelDelta(pos) => pos.y,
                 };
                 if let Some(entry) = state.windows.get_mut(&wid)
-                    && event_dispatch::handle_mouse_wheel(&mut entry.dom, scroll_delta_y)
+                    && let Some(handle) = entry.handle.as_mut()
+                    && event_dispatch::handle_mouse_wheel(&mut entry.dom, handle, scroll_delta_y)
                 {
                     needs_redraw = true;
                 }

--- a/crates/uzumaki/src/element.rs
+++ b/crates/uzumaki/src/element.rs
@@ -110,7 +110,7 @@ impl ElementNode {
     }
 
     pub fn new_text_input(state: InputState) -> Self {
-        Self::new(ElementData::TextInput(state))
+        Self::new(ElementData::TextInput(Box::new(state)))
     }
 
     pub fn is_text_input(&self) -> bool {
@@ -129,7 +129,7 @@ impl ElementNode {
 #[derive(Default)]
 pub enum ElementData {
     // this is text Element <text>
-    TextInput(InputState),
+    TextInput(Box<InputState>),
     // for view nodes
     #[default]
     None,

--- a/crates/uzumaki/src/element/input.rs
+++ b/crates/uzumaki/src/element/input.rs
@@ -112,23 +112,23 @@ pub fn paint_input(
             let oy = if input.multiline {
                 text_y + top_pad - scroll_y
             } else {
-                text_y + ((text_h as f64 - line_height as f64) / 2.0).max(0.0)
+                text_y + ((text_h - line_height as f64) / 2.0).max(0.0)
             };
             for rect in &input.selection_rects {
-                let x1 = text_x + rect.x0 as f64
+                let x1 = text_x + rect.x0
                     - if input.multiline {
                         0.0
                     } else {
                         input.scroll_offset as f64
                     };
-                let x2 = text_x + rect.x1 as f64
+                let x2 = text_x + rect.x1
                     - if input.multiline {
                         0.0
                     } else {
                         input.scroll_offset as f64
                     };
-                let y1 = oy + rect.y0 as f64;
-                let y2 = oy + rect.y1 as f64;
+                let y1 = oy + rect.y0;
+                let y2 = oy + rect.y1;
                 scene.fill(
                     Fill::NonZero,
                     Affine::scale(scale),
@@ -173,97 +173,94 @@ pub fn paint_input(
     }
 
     // Preedit (IME composition text)
-    if let Some(preedit) = &input.preedit {
-        if let Some(cr) = &input.cursor_rect {
-            let oy = if input.multiline {
-                text_y + top_pad - scroll_y
+    if let Some(preedit) = &input.preedit
+        && let Some(cr) = &input.cursor_rect
+    {
+        let oy = if input.multiline {
+            text_y + top_pad - scroll_y
+        } else {
+            text_y + ((text_h - line_height as f64) / 2.0).max(0.0)
+        };
+        let px = text_x + cr.x0
+            - if input.multiline {
+                0.0
             } else {
-                text_y + ((text_h as f64 - line_height as f64) / 2.0).max(0.0)
+                input.scroll_offset as f64
             };
-            let px = text_x + cr.x0 as f64
-                - if input.multiline {
-                    0.0
-                } else {
-                    input.scroll_offset as f64
-                };
-            let py = oy + cr.y0 as f64;
-            let preedit_h = cr.y1 as f64 - cr.y0 as f64;
+        let py = oy + cr.y0;
+        let preedit_h = cr.y1 - cr.y0;
 
-            // Background highlight for preedit
-            let preedit_bg = VelloColor::from_rgba8(50, 50, 60, 180);
-            let preedit_rect = Rect::new(px, py, px + preedit.width as f64, py + preedit_h);
-            scene.fill(
-                Fill::NonZero,
-                Affine::scale(scale),
-                preedit_bg,
-                None,
-                &preedit_rect,
-            );
+        // Background highlight for preedit
+        let preedit_bg = VelloColor::from_rgba8(50, 50, 60, 180);
+        let preedit_rect = Rect::new(px, py, px + preedit.width as f64, py + preedit_h);
+        scene.fill(
+            Fill::NonZero,
+            Affine::scale(scale),
+            preedit_bg,
+            None,
+            &preedit_rect,
+        );
 
-            // Preedit text
-            text_renderer.draw_text(
-                scene,
-                &preedit.text,
-                input.font_size,
-                preedit.width + 100.0,
-                text_h as f32,
-                (px as f32, py as f32),
-                input.text_color.to_vello(),
-                scale,
-            );
+        // Preedit text
+        text_renderer.draw_text(
+            scene,
+            &preedit.text,
+            input.font_size,
+            preedit.width + 100.0,
+            text_h as f32,
+            (px as f32, py as f32),
+            input.text_color.to_vello(),
+            scale,
+        );
 
-            // Underline
-            let underline_y = py + preedit_h - 1.0;
-            let underline = Rect::new(
-                px,
-                underline_y,
-                px + preedit.width as f64,
-                underline_y + 1.0,
-            );
-            scene.fill(
-                Fill::NonZero,
-                Affine::scale(scale),
-                VelloColor::from_rgba8(180, 180, 180, 255),
-                None,
-                &underline,
-            );
-        }
+        // Underline
+        let underline_y = py + preedit_h - 1.0;
+        let underline = Rect::new(
+            px,
+            underline_y,
+            px + preedit.width as f64,
+            underline_y + 1.0,
+        );
+        scene.fill(
+            Fill::NonZero,
+            Affine::scale(scale),
+            VelloColor::from_rgba8(180, 180, 180, 255),
+            None,
+            &underline,
+        );
     }
 
     // Cursor (hide during preedit)
-    if input.focused && input.blink_visible && input.preedit.is_none() {
-        if let Some(cr) = &input.cursor_rect {
-            let oy = if input.multiline {
-                text_y + top_pad - scroll_y
+    if input.focused
+        && input.blink_visible
+        && input.preedit.is_none()
+        && let Some(cr) = &input.cursor_rect
+    {
+        let oy = if input.multiline {
+            text_y + top_pad - scroll_y
+        } else {
+            text_y + ((text_h - line_height as f64) / 2.0).max(0.0)
+        };
+        let cx = text_x + cr.x0
+            - if input.multiline {
+                0.0
             } else {
-                text_y + ((text_h as f64 - line_height as f64) / 2.0).max(0.0)
+                input.scroll_offset as f64
             };
-            let cx = text_x + cr.x0 as f64
-                - if input.multiline {
-                    0.0
-                } else {
-                    input.scroll_offset as f64
-                };
-            let cy = oy + cr.y0 as f64;
-            let cursor_rect = Rect::new(
-                cx,
-                cy + 2.0,
-                cx + 1.5,
-                cy + cr.y1 as f64 - cr.y0 as f64 - 2.0,
-            );
-            scene.fill(
-                Fill::NonZero,
-                Affine::scale(scale),
-                VelloColor::from_rgba8(212, 212, 212, 255),
-                None,
-                &cursor_rect,
-            );
-        }
+        let cy = oy + cr.y0;
+        let cursor_rect = Rect::new(cx, cy + 2.0, cx + 1.5, cy + cr.y1 - cr.y0 - 2.0);
+        scene.fill(
+            Fill::NonZero,
+            Affine::scale(scale),
+            VelloColor::from_rgba8(212, 212, 212, 255),
+            None,
+            &cursor_rect,
+        );
     }
 
     scene.pop_layer();
 
-    let content_info = if input.multiline {
+    if input.multiline {
         let content_height = input.layout_height as f64 + top_pad;
         Some(InputContentInfo {
             content_height,
@@ -272,6 +269,5 @@ pub fn paint_input(
         })
     } else {
         None
-    };
-    content_info
+    }
 }

--- a/crates/uzumaki/src/element/input.rs
+++ b/crates/uzumaki/src/element/input.rs
@@ -232,7 +232,6 @@ fn paint_multiline(
         text_renderer.draw_text(
             scene,
             &input.placeholder,
-            cosmic_text::Attrs::new(),
             input.font_size,
             text_w as f32,
             text_h as f32,
@@ -265,7 +264,6 @@ fn paint_multiline(
         text_renderer.draw_text(
             scene,
             &input.display_text,
-            cosmic_text::Attrs::new(),
             input.font_size,
             text_w as f32,
             text_h as f32 + input.scroll_offset_y + 10000.0,
@@ -362,7 +360,6 @@ fn paint_singleline(
         text_renderer.draw_text(
             scene,
             &input.placeholder,
-            cosmic_text::Attrs::new(),
             input.font_size,
             text_w as f32,
             text_h as f32,
@@ -397,7 +394,6 @@ fn paint_singleline(
         text_renderer.draw_text(
             scene,
             &input.display_text,
-            cosmic_text::Attrs::new(),
             input.font_size,
             text_w as f32 + input.scroll_offset + 10000.0,
             text_h as f32,

--- a/crates/uzumaki/src/element/input.rs
+++ b/crates/uzumaki/src/element/input.rs
@@ -1,32 +1,37 @@
+use parley::BoundingBox;
 use vello::Scene;
 use vello::kurbo::{Affine, Rect};
 use vello::peniko::{Color as VelloColor, Fill};
 
 use crate::style::{Bounds, Color, Corners, Edges, UzStyle};
-use crate::text::{GlyphPos2D, TextRenderer};
+use crate::text::TextRenderer;
 
-/// Returned by `paint_input` for multiline inputs so the caller can render a scrollbar.
 pub struct InputContentInfo {
     pub content_height: f64,
     pub visible_height: f64,
     pub scroll_offset_y: f64,
 }
 
-/// Snapshot of input state collected during the render-tree walk.
-/// Decouples painting from the live InputState/Node.
 pub struct InputRenderInfo {
     pub display_text: String,
     pub placeholder: String,
     pub font_size: f32,
     pub text_color: Color,
     pub focused: bool,
-    pub sel_start: usize,
-    pub sel_end: usize,
-    pub cursor_pos: usize,
+    pub cursor_rect: Option<BoundingBox>,
+    pub selection_rects: Vec<BoundingBox>,
     pub scroll_offset: f32,
     pub scroll_offset_y: f32,
     pub blink_visible: bool,
     pub multiline: bool,
+    pub layout_height: f32,
+    pub preedit: Option<PreeditRenderInfo>,
+}
+
+pub struct PreeditRenderInfo {
+    pub text: String,
+    pub cursor_x: f32,
+    pub width: f32,
 }
 
 /// Paint an input element with its text, selection highlight, and cursor.
@@ -73,562 +78,200 @@ pub fn paint_input(
 
     let is_empty = input.display_text.is_empty();
     let line_height = (input.font_size * 1.2).round();
+    let scroll_y = input.scroll_offset_y as f64;
 
-    let content_info = if input.multiline {
-        Some(paint_multiline(
-            scene,
-            text_renderer,
-            input,
-            text_x,
-            text_y,
-            text_w,
-            text_h,
-            line_height,
-            is_empty,
-            style,
-            scale,
-        ))
-    } else {
-        paint_singleline(
-            scene,
-            text_renderer,
-            input,
-            text_x,
-            text_y,
-            text_w,
-            text_h,
-            line_height,
-            is_empty,
-            scale,
-        );
-        None
-    };
-
-    scene.pop_layer();
-    content_info
-}
-
-// ── Coordinate helpers ───────────────────────────────────────────────
-
-/// Convert a position from `grapheme_positions_2d` to screen coordinates.
-/// Single source of truth for the positions→screen transform used by both
-/// cursor and selection painting.
-pub(crate) fn to_screen(
-    pos: GlyphPos2D,
-    text_x: f64,
-    text_y: f64,
-    top_pad: f64,
-    scroll_y: f64,
-) -> (f64, f64) {
-    (
-        text_x + pos.x as f64,
-        text_y + pos.y as f64 + top_pad - scroll_y,
-    )
-}
-
-/// Compute selection highlight rectangles in positions-relative coordinates.
-/// Returns `(x1, y, x2, y + line_height)` rects — the caller applies the
-/// screen offset via `to_screen` / the shared `(text_x, text_y + top_pad - scroll_y)`.
-///
-/// Coordinate system: x is relative to text-area left edge (0 = left),
-/// y is the zero-based line-top from `grapheme_positions_2d`.
-pub(crate) fn compute_selection_rects(
-    positions: &[GlyphPos2D],
-    sel_start: usize,
-    sel_end: usize,
-    _text_w: f64,
-    line_height: f64,
-) -> Vec<[f64; 4]> {
-    if sel_start >= sel_end || positions.is_empty() {
-        return vec![];
-    }
-
-    let sel_end_idx = sel_end.min(positions.len() - 1);
-    let start_x = positions[sel_start].x as f64;
-    let end_x = positions[sel_end_idx].x as f64;
-
-    // Collect unique visual line y-values within the selection range
-    let mut line_ys: Vec<f32> = Vec::new();
-    for pos in &positions[sel_start..=sel_end_idx] {
-        let y = pos.y;
-        if line_ys.last().is_none_or(|&ly| (y - ly).abs() > 1.0) {
-            line_ys.push(y);
-        }
-    }
-
-    let num_lines = line_ys.len();
-    let mut rects = Vec::new();
-
-    for (idx, &ly) in line_ys.iter().enumerate() {
-        let y = ly as f64;
-        let line_end_x = positions
-            .iter()
-            .filter(|pos| (pos.y - ly).abs() < 1.0)
-            .map(|pos| pos.x as f64)
-            .fold(0.0, f64::max);
-
-        let (x1, x2) = if num_lines == 1 {
-            // Single visual line — exact start-to-end
-            (start_x, end_x)
-        } else if idx == 0 {
-            // First line: from selection start to the line's rendered extent
-            (start_x, line_end_x)
-        } else if idx == num_lines - 1 {
-            // Last line: from left edge to selection end
-            if end_x < 1.0 {
-                // Selection ends at start-of-line (after a newline) — small stub
-                (0.0, 8.0)
-            } else {
-                (0.0, end_x)
-            }
-        } else {
-            // Middle line: clamp to the line's rendered extent, or stub for empty lines
-            if line_end_x > 1.0 {
-                (0.0, line_end_x)
-            } else {
-                (0.0, 8.0)
-            }
-        };
-
-        if x2 > x1 {
-            rects.push([x1, y, x2, y + line_height]);
-        }
-    }
-
-    rects
-}
-
-// ── Multiline input rendering ────────────────────────────────────────
-
-#[allow(clippy::too_many_arguments)]
-fn paint_multiline(
-    scene: &mut Scene,
-    text_renderer: &mut TextRenderer,
-    input: &InputRenderInfo,
-    text_x: f64,
-    text_y: f64,
-    text_w: f64,
-    text_h: f64,
-    line_height: f32,
-    is_empty: bool,
-    style: &UzStyle,
-    scale: f64,
-) -> InputContentInfo {
     let top_pad: f64 = if style.padding.top > 0.0 {
         style.padding.top as f64
     } else {
         4.0
     };
-    let scroll_y: f64 = input.scroll_offset_y as f64;
-    let wrap_width = Some(text_w as f32);
 
-    let positions = if !is_empty {
-        text_renderer.grapheme_positions_2d(&input.display_text, input.font_size, wrap_width)
-    } else {
-        vec![GlyphPos2D { x: 0.0, y: 0.0 }]
-    };
-
+    // Placeholder
     if is_empty && !input.placeholder.is_empty() {
+        let py = if input.multiline {
+            (text_y + top_pad) as f32
+        } else {
+            text_y as f32 + ((text_h as f32 - line_height) / 2.0).max(0.0)
+        };
         text_renderer.draw_text(
             scene,
             &input.placeholder,
             input.font_size,
             text_w as f32,
             text_h as f32,
-            (text_x as f32, (text_y + top_pad - scroll_y) as f32),
+            (text_x as f32, py),
             VelloColor::from_rgba8(128, 128, 128, 255),
             scale,
         );
-    } else if !is_empty {
-        // Draw selection highlight
-        if input.focused
-            && input.sel_start != input.sel_end
-            && input.sel_start < positions.len()
-            && input.sel_end <= positions.len()
-        {
-            paint_multiline_selection(
-                scene,
-                &positions,
-                input,
-                text_x,
-                text_y,
-                text_w,
-                line_height,
-                top_pad,
-                scroll_y,
-                scale,
-            );
+    }
+
+    if !is_empty {
+        // Selection highlights
+        if input.focused && !input.selection_rects.is_empty() {
+            let sel_color = VelloColor::from_rgba8(56, 121, 185, 128);
+            let oy = if input.multiline {
+                text_y + top_pad - scroll_y
+            } else {
+                text_y + ((text_h as f64 - line_height as f64) / 2.0).max(0.0)
+            };
+            for rect in &input.selection_rects {
+                let x1 = text_x + rect.x0 as f64
+                    - if input.multiline {
+                        0.0
+                    } else {
+                        input.scroll_offset as f64
+                    };
+                let x2 = text_x + rect.x1 as f64
+                    - if input.multiline {
+                        0.0
+                    } else {
+                        input.scroll_offset as f64
+                    };
+                let y1 = oy + rect.y0 as f64;
+                let y2 = oy + rect.y1 as f64;
+                scene.fill(
+                    Fill::NonZero,
+                    Affine::scale(scale),
+                    sel_color,
+                    None,
+                    &Rect::new(x1, y1, x2, y2),
+                );
+            }
         }
 
-        // Draw text with wrapping
+        // Text
+        let ty = if input.multiline {
+            (text_y + top_pad - scroll_y) as f32
+        } else {
+            text_y as f32 + ((text_h as f32 - line_height) / 2.0).max(0.0)
+        };
+        let tw = if input.multiline {
+            text_w as f32
+        } else {
+            text_w as f32 + input.scroll_offset + 10000.0
+        };
+        let tx = if input.multiline {
+            text_x as f32
+        } else {
+            text_x as f32 - input.scroll_offset
+        };
         text_renderer.draw_text(
             scene,
             &input.display_text,
             input.font_size,
-            text_w as f32,
-            text_h as f32 + input.scroll_offset_y + 10000.0,
-            (text_x as f32, (text_y + top_pad - scroll_y) as f32),
+            tw,
+            text_h as f32
+                + if input.multiline {
+                    input.scroll_offset_y + 10000.0
+                } else {
+                    0.0
+                },
+            (tx, ty),
             input.text_color.to_vello(),
             scale,
         );
     }
 
-    // Draw cursor — uses same to_screen transform as selection
-    if input.focused && input.blink_visible && !positions.is_empty() {
-        let cp = if input.cursor_pos < positions.len() {
-            positions[input.cursor_pos]
-        } else {
-            *positions.last().unwrap()
-        };
-        let (cx, cy) = to_screen(cp, text_x, text_y, top_pad, scroll_y);
-        paint_cursor(scene, cx, cy, line_height, scale);
-    }
+    // Preedit (IME composition text)
+    if let Some(preedit) = &input.preedit {
+        if let Some(cr) = &input.cursor_rect {
+            let oy = if input.multiline {
+                text_y + top_pad - scroll_y
+            } else {
+                text_y + ((text_h as f64 - line_height as f64) / 2.0).max(0.0)
+            };
+            let px = text_x + cr.x0 as f64
+                - if input.multiline {
+                    0.0
+                } else {
+                    input.scroll_offset as f64
+                };
+            let py = oy + cr.y0 as f64;
+            let preedit_h = cr.y1 as f64 - cr.y0 as f64;
 
-    // Content height = last line's y + one line_height + top padding
-    let last_y = positions.last().map_or(0.0, |p| p.y as f64);
-    let content_height = last_y + line_height as f64 + top_pad;
+            // Background highlight for preedit
+            let preedit_bg = VelloColor::from_rgba8(50, 50, 60, 180);
+            let preedit_rect = Rect::new(px, py, px + preedit.width as f64, py + preedit_h);
+            scene.fill(
+                Fill::NonZero,
+                Affine::scale(scale),
+                preedit_bg,
+                None,
+                &preedit_rect,
+            );
 
-    InputContentInfo {
-        content_height,
-        visible_height: text_h,
-        scroll_offset_y: scroll_y,
-    }
-}
+            // Preedit text
+            text_renderer.draw_text(
+                scene,
+                &preedit.text,
+                input.font_size,
+                preedit.width + 100.0,
+                text_h as f32,
+                (px as f32, py as f32),
+                input.text_color.to_vello(),
+                scale,
+            );
 
-#[allow(clippy::too_many_arguments)]
-fn paint_multiline_selection(
-    scene: &mut Scene,
-    positions: &[GlyphPos2D],
-    input: &InputRenderInfo,
-    text_x: f64,
-    text_y: f64,
-    text_w: f64,
-    line_height: f32,
-    top_pad: f64,
-    scroll_y: f64,
-    scale: f64,
-) {
-    let sel_color = VelloColor::from_rgba8(56, 121, 185, 128);
-
-    let rects = compute_selection_rects(
-        positions,
-        input.sel_start,
-        input.sel_end,
-        text_w,
-        line_height as f64,
-    );
-
-    // Apply the same screen offset used by cursor and text drawing
-    let ox = text_x;
-    let oy = text_y + top_pad - scroll_y;
-
-    for [x1, y1, x2, y2] in rects {
-        scene.fill(
-            Fill::NonZero,
-            Affine::scale(scale),
-            sel_color,
-            None,
-            &Rect::new(ox + x1, oy + y1, ox + x2, oy + y2),
-        );
-    }
-}
-
-// ── Single-line input rendering ──────────────────────────────────────
-
-#[allow(clippy::too_many_arguments)]
-fn paint_singleline(
-    scene: &mut Scene,
-    text_renderer: &mut TextRenderer,
-    input: &InputRenderInfo,
-    text_x: f64,
-    text_y: f64,
-    text_w: f64,
-    text_h: f64,
-    line_height: f32,
-    is_empty: bool,
-    scale: f64,
-) {
-    let text_offset_y = ((text_h as f32 - line_height) / 2.0).max(0.0);
-
-    let positions = if !is_empty {
-        text_renderer.grapheme_x_positions(&input.display_text, input.font_size)
-    } else {
-        vec![0.0]
-    };
-
-    if is_empty && !input.placeholder.is_empty() {
-        text_renderer.draw_text(
-            scene,
-            &input.placeholder,
-            input.font_size,
-            text_w as f32,
-            text_h as f32,
-            (text_x as f32, text_y as f32 + text_offset_y),
-            VelloColor::from_rgba8(128, 128, 128, 255),
-            scale,
-        );
-    } else if !is_empty {
-        // Draw selection highlight
-        if input.focused
-            && input.sel_start != input.sel_end
-            && input.sel_start < positions.len()
-            && input.sel_end <= positions.len()
-        {
-            let x1 = (positions[input.sel_start] - input.scroll_offset) as f64;
-            let x2 = (positions[input.sel_end] - input.scroll_offset) as f64;
-            let sel_rect = Rect::new(
-                text_x + x1,
-                text_y + text_offset_y as f64,
-                text_x + x2,
-                text_y + text_offset_y as f64 + line_height as f64,
+            // Underline
+            let underline_y = py + preedit_h - 1.0;
+            let underline = Rect::new(
+                px,
+                underline_y,
+                px + preedit.width as f64,
+                underline_y + 1.0,
             );
             scene.fill(
                 Fill::NonZero,
                 Affine::scale(scale),
-                VelloColor::from_rgba8(56, 121, 185, 128),
+                VelloColor::from_rgba8(180, 180, 180, 255),
                 None,
-                &sel_rect,
+                &underline,
             );
         }
-
-        text_renderer.draw_text(
-            scene,
-            &input.display_text,
-            input.font_size,
-            text_w as f32 + input.scroll_offset + 10000.0,
-            text_h as f32,
-            (
-                text_x as f32 - input.scroll_offset,
-                text_y as f32 + text_offset_y,
-            ),
-            input.text_color.to_vello(),
-            scale,
-        );
     }
 
-    // Draw cursor
-    if input.focused && input.blink_visible {
-        let cursor_x = if input.cursor_pos < positions.len() {
-            (positions[input.cursor_pos] - input.scroll_offset) as f64
-        } else {
-            0.0
-        };
-        paint_cursor(
-            scene,
-            text_x + cursor_x,
-            text_y + text_offset_y as f64,
-            line_height,
-            scale,
-        );
-    }
-}
-
-// ── Shared helpers ───────────────────────────────────────────────────
-
-fn paint_cursor(scene: &mut Scene, x: f64, y: f64, line_height: f32, scale: f64) {
-    let cursor_rect = Rect::new(x, y + 2.0, x + 1.5, y + line_height as f64 - 2.0);
-    scene.fill(
-        Fill::NonZero,
-        Affine::scale(scale),
-        VelloColor::from_rgba8(212, 212, 212, 255),
-        None,
-        &cursor_rect,
-    );
-}
-
-// ── Tests ────────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn p(x: f32, y: f32) -> GlyphPos2D {
-        GlyphPos2D { x, y }
+    // Cursor (hide during preedit)
+    if input.focused && input.blink_visible && input.preedit.is_none() {
+        if let Some(cr) = &input.cursor_rect {
+            let oy = if input.multiline {
+                text_y + top_pad - scroll_y
+            } else {
+                text_y + ((text_h as f64 - line_height as f64) / 2.0).max(0.0)
+            };
+            let cx = text_x + cr.x0 as f64
+                - if input.multiline {
+                    0.0
+                } else {
+                    input.scroll_offset as f64
+                };
+            let cy = oy + cr.y0 as f64;
+            let cursor_rect = Rect::new(
+                cx,
+                cy + 2.0,
+                cx + 1.5,
+                cy + cr.y1 as f64 - cr.y0 as f64 - 2.0,
+            );
+            scene.fill(
+                Fill::NonZero,
+                Affine::scale(scale),
+                VelloColor::from_rgba8(212, 212, 212, 255),
+                None,
+                &cursor_rect,
+            );
+        }
     }
 
-    // ── to_screen ───────────────────────────────────────────────────
+    scene.pop_layer();
 
-    #[test]
-    fn to_screen_basic() {
-        let (sx, sy) = to_screen(p(10.0, 20.0), 100.0, 50.0, 4.0, 0.0);
-        assert_eq!(sx, 110.0); // text_x + pos.x
-        assert_eq!(sy, 74.0); // text_y + pos.y + top_pad
-    }
-
-    #[test]
-    fn to_screen_with_scroll() {
-        let (sx, sy) = to_screen(p(10.0, 20.0), 100.0, 50.0, 4.0, 10.0);
-        assert_eq!(sx, 110.0);
-        assert_eq!(sy, 64.0); // 50 + 20 + 4 - 10
-    }
-
-    #[test]
-    fn to_screen_origin() {
-        let (sx, sy) = to_screen(p(0.0, 0.0), 8.0, 0.0, 4.0, 0.0);
-        assert_eq!(sx, 8.0);
-        assert_eq!(sy, 4.0);
-    }
-
-    #[test]
-    fn to_screen_consistency_across_lines() {
-        // Cursor on line 0 and line 1 should differ by exactly line_y_delta
-        let line_height = 20.0f32;
-        let (_, y0) = to_screen(p(5.0, 0.0), 0.0, 0.0, 4.0, 0.0);
-        let (_, y1) = to_screen(p(5.0, line_height), 0.0, 0.0, 4.0, 0.0);
-        assert!((y1 - y0 - line_height as f64).abs() < 0.01);
-    }
-
-    // ── compute_selection_rects ─────────────────────────────────────
-
-    #[test]
-    fn sel_rect_empty_selection() {
-        let positions = vec![p(0.0, 0.0), p(10.0, 0.0)];
-        let rects = compute_selection_rects(&positions, 1, 1, 200.0, 20.0);
-        assert!(rects.is_empty());
-    }
-
-    #[test]
-    fn sel_rect_empty_positions() {
-        let rects = compute_selection_rects(&[], 0, 1, 200.0, 20.0);
-        assert!(rects.is_empty());
-    }
-
-    #[test]
-    fn sel_rect_single_line() {
-        // "abc" on line 0: positions at x = 0, 10, 20, 30
-        let positions = vec![p(0.0, 0.0), p(10.0, 0.0), p(20.0, 0.0), p(30.0, 0.0)];
-        let rects = compute_selection_rects(&positions, 1, 3, 200.0, 20.0);
-        assert_eq!(rects.len(), 1);
-        assert_eq!(rects[0], [10.0, 0.0, 30.0, 20.0]);
-    }
-
-    #[test]
-    fn sel_rect_single_line_from_start() {
-        let positions = vec![p(0.0, 0.0), p(10.0, 0.0), p(20.0, 0.0)];
-        let rects = compute_selection_rects(&positions, 0, 2, 200.0, 20.0);
-        assert_eq!(rects.len(), 1);
-        assert_eq!(rects[0], [0.0, 0.0, 20.0, 20.0]);
-    }
-
-    #[test]
-    fn sel_rect_two_lines() {
-        // Line 0: positions 0-2 at y=0, Line 1: positions 3-5 at y=20
-        let positions = vec![
-            p(0.0, 0.0),
-            p(10.0, 0.0),
-            p(20.0, 0.0), // line 0
-            p(0.0, 20.0),
-            p(10.0, 20.0),
-            p(20.0, 20.0), // line 1
-        ];
-        let rects = compute_selection_rects(&positions, 1, 4, 200.0, 20.0);
-        assert_eq!(rects.len(), 2);
-        // First line: start_x=10 to the rendered end of line 0
-        assert_eq!(rects[0], [10.0, 0.0, 20.0, 20.0]);
-        // Last line: 0 to end_x=10
-        assert_eq!(rects[1], [0.0, 20.0, 10.0, 40.0]);
-    }
-
-    #[test]
-    fn sel_rect_three_lines_middle_full_width() {
-        let positions = vec![
-            p(0.0, 0.0),
-            p(10.0, 0.0), // line 0
-            p(0.0, 20.0),
-            p(15.0, 20.0), // line 1
-            p(0.0, 40.0),
-            p(10.0, 40.0), // line 2
-        ];
-        let rects = compute_selection_rects(&positions, 0, 5, 200.0, 20.0);
-        assert_eq!(rects.len(), 3);
-        // First line → rendered end of line 0
-        assert_eq!(rects[0], [0.0, 0.0, 10.0, 20.0]);
-        // Middle line → rendered end of line 1
-        assert_eq!(rects[1], [0.0, 20.0, 15.0, 40.0]);
-        // Last line → left to end_x
-        assert_eq!(rects[2], [0.0, 40.0, 10.0, 60.0]);
-    }
-
-    #[test]
-    fn sel_rect_last_line_at_x_zero_gets_stub() {
-        // Selection ends at start of new line (after \n)
-        let positions = vec![
-            p(0.0, 0.0),
-            p(10.0, 0.0),
-            p(20.0, 0.0),
-            p(30.0, 0.0), // line 0: "abc"
-            p(0.0, 20.0), // line 1: after \n, x=0
-        ];
-        let rects = compute_selection_rects(&positions, 0, 4, 200.0, 20.0);
-        assert_eq!(rects.len(), 2);
-        // First line ends at the rendered end of line 0
-        assert_eq!(rects[0], [0.0, 0.0, 30.0, 20.0]);
-        // Last line: stub (end_x < 1.0)
-        assert_eq!(rects[1], [0.0, 20.0, 8.0, 40.0]);
-    }
-
-    #[test]
-    fn sel_rect_empty_middle_line_gets_stub() {
-        // Line 0 has content, line 1 is empty (only x=0), line 2 has content
-        let positions = vec![
-            p(0.0, 0.0),
-            p(10.0, 0.0), // line 0
-            p(0.0, 20.0), // line 1 (empty — only x=0 position)
-            p(0.0, 40.0),
-            p(10.0, 40.0), // line 2
-        ];
-        let rects = compute_selection_rects(&positions, 0, 4, 200.0, 20.0);
-        assert_eq!(rects.len(), 3);
-        assert_eq!(rects[0], [0.0, 0.0, 10.0, 20.0]); // first line
-        assert_eq!(rects[1], [0.0, 20.0, 8.0, 40.0]); // empty middle → stub
-        assert_eq!(rects[2], [0.0, 40.0, 10.0, 60.0]); // last line
-    }
-
-    #[test]
-    fn sel_rect_sel_end_clamped_to_positions_len() {
-        let positions = vec![p(0.0, 0.0), p(10.0, 0.0), p(20.0, 0.0)];
-        // sel_end beyond positions.len() should be clamped
-        let rects = compute_selection_rects(&positions, 0, 100, 200.0, 20.0);
-        assert_eq!(rects.len(), 1);
-        assert_eq!(rects[0], [0.0, 0.0, 20.0, 20.0]);
-    }
-
-    // ── Integration: to_screen + compute_selection_rects ────────────
-
-    #[test]
-    fn cursor_and_selection_use_same_offset() {
-        // Verify that cursor at sel_start and selection rect start coincide
-        let positions = vec![
-            p(0.0, 0.0),
-            p(10.0, 0.0),
-            p(20.0, 0.0),
-            p(0.0, 20.0),
-            p(10.0, 20.0),
-        ];
-        let text_x = 50.0;
-        let text_y = 100.0;
-        let top_pad = 4.0;
-        let scroll_y = 0.0;
-
-        // Cursor at position 1
-        let (cx, cy) = to_screen(positions[1], text_x, text_y, top_pad, scroll_y);
-
-        // Selection starting at position 1
-        let rects = compute_selection_rects(&positions, 1, 3, 200.0, 20.0);
-        let sel_x = text_x + rects[0][0]; // offset applied by caller
-        let sel_y = text_y + top_pad - scroll_y + rects[0][1];
-
-        assert!(
-            (cx - sel_x).abs() < 0.01,
-            "cursor x and selection start x must match: {} vs {}",
-            cx,
-            sel_x
-        );
-        assert!(
-            (cy - sel_y).abs() < 0.01,
-            "cursor y and selection start y must match: {} vs {}",
-            cy,
-            sel_y
-        );
-    }
+    let content_info = if input.multiline {
+        let content_height = input.layout_height as f64 + top_pad;
+        Some(InputContentInfo {
+            content_height,
+            visible_height: text_h,
+            scroll_offset_y: scroll_y,
+        })
+    } else {
+        None
+    };
+    content_info
 }

--- a/crates/uzumaki/src/element/render.rs
+++ b/crates/uzumaki/src/element/render.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use cosmic_text::Attrs;
 use vello::Scene;
 use vello::kurbo::{Affine, Rect, RoundedRect, RoundedRectRadii};
 use vello::peniko::{Color as VelloColor, Fill};
@@ -418,7 +417,6 @@ impl<'a> Painter<'a> {
                     text_renderer.draw_text(
                         scene,
                         content,
-                        Attrs::new(),
                         *font_size,
                         bounds.width as f32,
                         bounds.height as f32,
@@ -607,7 +605,6 @@ pub(crate) fn measure(
     if let Some(text) = &ctx.text {
         let (measured_width, measured_height) = text_renderer.measure_text(
             &text.content,
-            Attrs::new(),
             ctx.font_size,
             known_dimensions
                 .width

--- a/crates/uzumaki/src/element/render.rs
+++ b/crates/uzumaki/src/element/render.rs
@@ -4,11 +4,65 @@ use vello::Scene;
 use vello::kurbo::{Affine, Rect, RoundedRect, RoundedRectRadii};
 use vello::peniko::{Color as VelloColor, Fill};
 
-use crate::element::input::{InputRenderInfo, compute_selection_rects};
+use crate::element::input::InputRenderInfo;
 use crate::element::{InheritedProperties, NodeContext, ScrollThumbRect, UzNodeId};
 use crate::style::{Bounds, Color, UzStyle, Visibility};
-use crate::text::TextRenderer;
+use crate::text::{GlyphPos2D, TextRenderer};
 use crate::ui::UIState;
+
+fn compute_selection_rects(
+    positions: &[GlyphPos2D],
+    sel_start: usize,
+    sel_end: usize,
+    _text_w: f64,
+    line_height: f64,
+) -> Vec<[f64; 4]> {
+    if sel_start >= sel_end || positions.is_empty() {
+        return vec![];
+    }
+    let sel_end_idx = sel_end.min(positions.len() - 1);
+    let start_x = positions[sel_start].x as f64;
+    let end_x = positions[sel_end_idx].x as f64;
+    let mut line_ys: Vec<f32> = Vec::new();
+    for pos in &positions[sel_start..=sel_end_idx] {
+        let y = pos.y;
+        if line_ys.last().is_none_or(|&ly| (y - ly).abs() > 1.0) {
+            line_ys.push(y);
+        }
+    }
+    let num_lines = line_ys.len();
+    let mut rects = Vec::new();
+    for (idx, &ly) in line_ys.iter().enumerate() {
+        let y = ly as f64;
+        let line_end_x = positions
+            .iter()
+            .filter(|pos| (pos.y - ly).abs() < 1.0)
+            .map(|pos| pos.x as f64)
+            .fold(0.0, f64::max);
+        let (x1, x2) = if num_lines == 1 {
+            (start_x, end_x)
+        } else if idx == 0 {
+            (start_x, line_end_x)
+        } else if idx == num_lines - 1 {
+            if end_x < 1.0 {
+                (0.0, 8.0)
+            } else {
+                (0.0, end_x)
+            }
+        } else {
+            if line_end_x > 1.0 {
+                (0.0, line_end_x)
+            } else {
+                (0.0, 8.0)
+            }
+        };
+        if x2 > x1 {
+            rects.push([x1, y, x2, y + line_height]);
+        }
+    }
+    rects
+}
+
 /// Renders an `ElementTree` into a Vello `Scene`. Also rebuilds hitboxes and
 /// scroll thumbs as a side effect of walking the tree.
 pub struct Painter<'a> {
@@ -77,7 +131,7 @@ impl<'a> Painter<'a> {
                         taffy_node,
                         computed_style,
                         text,
-                        input,
+                        input_snapshot,
                         needs_hitbox,
                         is_scrollable,
                         first_child,
@@ -108,24 +162,22 @@ impl<'a> Painter<'a> {
                             )
                         });
 
-                        let input = node.as_text_input().map(|is| {
-                            let range = is.range();
-                            InputRenderInfo {
-                                display_text: is.display_text(),
-                                placeholder: is.placeholder.clone(),
-                                font_size: computed_style.text.font_size,
-                                text_color: computed_style.text.color,
-                                focused: is.focused,
-                                sel_start: range.start(),
-                                sel_end: range.end(),
-                                cursor_pos: range.active,
-                                scroll_offset: is.scroll_offset,
-                                scroll_offset_y: is.scroll_offset_y,
-                                blink_visible: is.blink_visible(self.dom.window_focused),
-                                multiline: is.multiline,
-                            }
-                        });
-
+                        let is_input = node.is_text_input();
+                        let input_snapshot = if is_input {
+                            let is = node.as_text_input().unwrap();
+                            Some((
+                                is.display_text(),
+                                is.placeholder.clone(),
+                                is.focused,
+                                is.scroll_offset,
+                                is.scroll_offset_y,
+                                is.blink_visible(self.dom.window_focused),
+                                is.multiline,
+                                is.preedit.clone(),
+                            ))
+                        } else {
+                            None
+                        };
                         // Text nodes inside textSelect views need hitboxes for click-to-select
                         let selectable_text = inherited.text_selectable && node.is_text_node();
                         let needs_hitbox = node.interactivity.needs_hitbox() || selectable_text;
@@ -136,14 +188,13 @@ impl<'a> Painter<'a> {
                             taffy_node,
                             computed_style,
                             text,
-                            input,
+                            input_snapshot,
                             needs_hitbox,
                             is_scrollable,
                             first_child,
                             inherited,
                         )
                     };
-                    // immutable borrow of self.dom.nodes is now dropped
 
                     if computed_style.visibility == Visibility::Hidden {
                         continue;
@@ -151,6 +202,77 @@ impl<'a> Painter<'a> {
 
                     let Ok(layout) = self.dom.taffy.layout(taffy_node) else {
                         continue;
+                    };
+
+                    // Populate InputRenderInfo with geometry from PlainEditor (needs mut access)
+                    let input = if let Some((
+                        display_text,
+                        placeholder,
+                        focused,
+                        scroll_offset,
+                        scroll_offset_y,
+                        blink_visible,
+                        multiline,
+                        preedit_state,
+                    )) = input_snapshot
+                    {
+                        let padding: f32 = 8.0;
+                        let text_w = (layout.size.width - padding * 2.0).max(0.0);
+                        let node_mut = &mut self.dom.nodes[node_id];
+                        let is = node_mut.as_text_input_mut().unwrap();
+                        is.set_font_size(computed_style.text.font_size);
+                        if multiline {
+                            is.set_width(Some(text_w));
+                        } else {
+                            is.set_width(None);
+                        }
+                        is.refresh_layout(&mut self.text_renderer);
+                        let cursor_rect = if blink_visible || preedit_state.is_some() {
+                            is.display_cursor_geometry(1.5, &mut self.text_renderer)
+                        } else {
+                            None
+                        };
+                        let selection_rects =
+                            is.display_selection_geometry(&mut self.text_renderer);
+                        let layout_height =
+                            is.editor.try_layout().map(|l| l.height()).unwrap_or(0.0);
+                        let preedit = preedit_state.map(|ps| {
+                            let font_size = computed_style.text.font_size;
+                            let positions =
+                                self.text_renderer.grapheme_x_positions(&ps.text, font_size);
+                            let width = *positions.last().unwrap_or(&0.0);
+                            crate::element::input::PreeditRenderInfo {
+                                text: ps.text,
+                                cursor_x: ps
+                                    .cursor
+                                    .map(|(start, _)| {
+                                        if start < positions.len() {
+                                            positions[start]
+                                        } else {
+                                            width
+                                        }
+                                    })
+                                    .unwrap_or(width),
+                                width,
+                            }
+                        });
+                        Some(InputRenderInfo {
+                            display_text,
+                            placeholder,
+                            font_size: computed_style.text.font_size,
+                            text_color: computed_style.text.color,
+                            focused,
+                            cursor_rect,
+                            selection_rects,
+                            scroll_offset,
+                            scroll_offset_y,
+                            blink_visible,
+                            multiline,
+                            layout_height,
+                            preedit,
+                        })
+                    } else {
+                        None
                     };
 
                     let x = parent_x + layout.location.x as f64;
@@ -531,8 +653,6 @@ impl<'a> Painter<'a> {
     }
 }
 
-// ── Render-only intermediate types ──────────────────────────────────
-
 struct RenderInfo {
     node_id: UzNodeId,
     x: f64,
@@ -572,8 +692,6 @@ enum StackItem {
     PopClip,
     PaintThumb(ThumbInfo),
 }
-
-// ── Measure (layout callback) ───────────────────────────────────────
 
 pub(crate) fn measure(
     text_renderer: &mut TextRenderer,
@@ -627,5 +745,115 @@ fn available_as_option(space: taffy::AvailableSpace) -> Option<f32> {
     match space {
         taffy::AvailableSpace::Definite(v) => Some(v),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(x: f32, y: f32) -> GlyphPos2D {
+        GlyphPos2D { x, y }
+    }
+
+    #[test]
+    fn sel_rect_empty_selection() {
+        let positions = vec![p(0.0, 0.0), p(10.0, 0.0)];
+        let rects = compute_selection_rects(&positions, 1, 1, 200.0, 20.0);
+        assert!(rects.is_empty());
+    }
+
+    #[test]
+    fn sel_rect_empty_positions() {
+        let rects = compute_selection_rects(&[], 0, 1, 200.0, 20.0);
+        assert!(rects.is_empty());
+    }
+
+    #[test]
+    fn sel_rect_single_line() {
+        let positions = vec![p(0.0, 0.0), p(10.0, 0.0), p(20.0, 0.0), p(30.0, 0.0)];
+        let rects = compute_selection_rects(&positions, 1, 3, 200.0, 20.0);
+        assert_eq!(rects.len(), 1);
+        assert_eq!(rects[0], [10.0, 0.0, 30.0, 20.0]);
+    }
+
+    #[test]
+    fn sel_rect_single_line_from_start() {
+        let positions = vec![p(0.0, 0.0), p(10.0, 0.0), p(20.0, 0.0)];
+        let rects = compute_selection_rects(&positions, 0, 2, 200.0, 20.0);
+        assert_eq!(rects.len(), 1);
+        assert_eq!(rects[0], [0.0, 0.0, 20.0, 20.0]);
+    }
+
+    #[test]
+    fn sel_rect_two_lines() {
+        let positions = vec![
+            p(0.0, 0.0),
+            p(10.0, 0.0),
+            p(20.0, 0.0),
+            p(0.0, 20.0),
+            p(10.0, 20.0),
+            p(20.0, 20.0),
+        ];
+        let rects = compute_selection_rects(&positions, 1, 4, 200.0, 20.0);
+        assert_eq!(rects.len(), 2);
+        assert_eq!(rects[0], [10.0, 0.0, 20.0, 20.0]);
+        assert_eq!(rects[1], [0.0, 20.0, 10.0, 40.0]);
+    }
+
+    #[test]
+    fn sel_rect_three_lines_middle_full_width() {
+        let positions = vec![
+            p(0.0, 0.0),
+            p(10.0, 0.0),
+            p(0.0, 20.0),
+            p(15.0, 20.0),
+            p(0.0, 40.0),
+            p(10.0, 40.0),
+        ];
+        let rects = compute_selection_rects(&positions, 0, 5, 200.0, 20.0);
+        assert_eq!(rects.len(), 3);
+        assert_eq!(rects[0], [0.0, 0.0, 10.0, 20.0]);
+        assert_eq!(rects[1], [0.0, 20.0, 15.0, 40.0]);
+        assert_eq!(rects[2], [0.0, 40.0, 10.0, 60.0]);
+    }
+
+    #[test]
+    fn sel_rect_last_line_at_x_zero_gets_stub() {
+        let positions = vec![
+            p(0.0, 0.0),
+            p(10.0, 0.0),
+            p(20.0, 0.0),
+            p(30.0, 0.0),
+            p(0.0, 20.0),
+        ];
+        let rects = compute_selection_rects(&positions, 0, 4, 200.0, 20.0);
+        assert_eq!(rects.len(), 2);
+        assert_eq!(rects[0], [0.0, 0.0, 30.0, 20.0]);
+        assert_eq!(rects[1], [0.0, 20.0, 8.0, 40.0]);
+    }
+
+    #[test]
+    fn sel_rect_empty_middle_line_gets_stub() {
+        let positions = vec![
+            p(0.0, 0.0),
+            p(10.0, 0.0),
+            p(0.0, 20.0),
+            p(0.0, 40.0),
+            p(10.0, 40.0),
+        ];
+        let rects = compute_selection_rects(&positions, 0, 4, 200.0, 20.0);
+        assert_eq!(rects.len(), 3);
+        assert_eq!(rects[0], [0.0, 0.0, 10.0, 20.0]);
+        assert_eq!(rects[1], [0.0, 20.0, 8.0, 40.0]);
+        assert_eq!(rects[2], [0.0, 40.0, 10.0, 60.0]);
+    }
+
+    #[test]
+    fn sel_rect_clamped_to_positions_len() {
+        let positions = vec![p(0.0, 0.0), p(10.0, 0.0), p(20.0, 0.0)];
+        let rects = compute_selection_rects(&positions, 0, 100, 200.0, 20.0);
+        assert_eq!(rects.len(), 1);
+        assert_eq!(rects[0], [0.0, 0.0, 20.0, 20.0]);
     }
 }

--- a/crates/uzumaki/src/element/render.rs
+++ b/crates/uzumaki/src/element/render.rs
@@ -49,13 +49,12 @@ fn compute_selection_rects(
             } else {
                 (0.0, end_x)
             }
+        } else if line_end_x > 1.0 {
+            (0.0, line_end_x)
         } else {
-            if line_end_x > 1.0 {
-                (0.0, line_end_x)
-            } else {
-                (0.0, 8.0)
-            }
+            (0.0, 8.0)
         };
+
         if x2 > x1 {
             rects.push([x1, y, x2, y + line_height]);
         }
@@ -226,14 +225,13 @@ impl<'a> Painter<'a> {
                         } else {
                             is.set_width(None);
                         }
-                        is.refresh_layout(&mut self.text_renderer);
+                        is.refresh_layout(self.text_renderer);
                         let cursor_rect = if blink_visible || preedit_state.is_some() {
-                            is.display_cursor_geometry(1.5, &mut self.text_renderer)
+                            is.display_cursor_geometry(1.5, self.text_renderer)
                         } else {
                             None
                         };
-                        let selection_rects =
-                            is.display_selection_geometry(&mut self.text_renderer);
+                        let selection_rects = is.display_selection_geometry(self.text_renderer);
                         let layout_height =
                             is.editor.try_layout().map(|l| l.height()).unwrap_or(0.0);
                         let preedit = preedit_state.map(|ps| {

--- a/crates/uzumaki/src/element/selection.rs
+++ b/crates/uzumaki/src/element/selection.rs
@@ -108,8 +108,12 @@ impl UIState {
             && let Some(node) = self.nodes.get(fid)
             && let Some(is) = node.as_text_input()
         {
-            let r = is.range();
-            return Some(TextSelection::new(fid, r.anchor, r.active));
+            let sel = is.editor.raw_selection();
+            return Some(TextSelection::new(
+                fid,
+                sel.anchor().index(),
+                sel.focus().index(),
+            ));
         }
         self.get_text_selection()
     }
@@ -120,7 +124,7 @@ impl UIState {
             && let Some(node) = self.nodes.get(fid)
             && let Some(is) = node.as_text_input()
         {
-            return Some(is.grapheme_count());
+            return Some(is.text().len());
         }
         let root = self.text_selection.root?;
         let run = self

--- a/crates/uzumaki/src/element/text.rs
+++ b/crates/uzumaki/src/element/text.rs
@@ -1,10 +1,8 @@
-use cosmic_text::Attrs;
 use vello::Scene;
 
 use crate::style::{Bounds, Color, UzStyle};
 use crate::text::TextRenderer;
 
-/// Paint a text element: background/borders from style, then text content.
 #[allow(clippy::too_many_arguments)]
 pub fn paint_text(
     scene: &mut Scene,
@@ -20,7 +18,6 @@ pub fn paint_text(
         text_renderer.draw_text(
             scene,
             content,
-            Attrs::new(),
             font_size,
             bounds.width as f32,
             bounds.height as f32,

--- a/crates/uzumaki/src/event_dispatch.rs
+++ b/crates/uzumaki/src/event_dispatch.rs
@@ -102,80 +102,152 @@ pub fn handle_redraw(
     handle.paint_and_present(device, queue, dom);
 }
 
+struct FocusedInputLayoutMeta {
+    taffy_x: f64,
+    taffy_y: f64,
+    input_padding: f32,
+    top_pad: f32,
+    multiline: bool,
+    font_size: f32,
+    input_width: f32,
+    input_height: f32,
+}
+
+fn focused_input_layout_meta(
+    dom: &UIState,
+    focused_id: UzNodeId,
+) -> Option<FocusedInputLayoutMeta> {
+    let node = dom.nodes.get(focused_id)?;
+    let is = node.as_text_input()?;
+    let padding = node.style.padding.left;
+    let input_padding = if padding > 0.0 { padding } else { 8.0 };
+    let pt = node.style.padding.top;
+    let top_pad = if pt > 0.0 { pt } else { 4.0 };
+    let font_size = node.style.text.font_size;
+    let layout = dom.taffy.layout(node.taffy_node).ok()?;
+    Some(FocusedInputLayoutMeta {
+        taffy_x: layout.location.x as f64,
+        taffy_y: layout.location.y as f64,
+        input_padding,
+        top_pad,
+        multiline: is.multiline,
+        font_size,
+        input_width: (layout.size.width - input_padding * 2.0).max(0.0),
+        input_height: layout.size.height,
+    })
+}
+
+fn sync_focused_input_cursor(
+    dom: &mut UIState,
+    handle: &mut Window,
+    focused_id: UzNodeId,
+    meta: &FocusedInputLayoutMeta,
+) -> Option<(parley::BoundingBox, f32, f32)> {
+    let node = dom.nodes.get_mut(focused_id)?;
+    let is = node.as_text_input_mut()?;
+    is.set_font_size(meta.font_size);
+    if meta.multiline {
+        is.set_width(Some(meta.input_width));
+    } else {
+        is.set_width(None);
+    }
+    is.refresh_layout(&mut handle.text_renderer);
+    let cursor_rect = is.display_cursor_geometry(1.5, &mut handle.text_renderer)?;
+    Some((cursor_rect, is.scroll_offset, is.scroll_offset_y))
+}
+
+fn set_ime_cursor_area(
+    handle: &mut Window,
+    meta: &FocusedInputLayoutMeta,
+    cursor_rect: &parley::BoundingBox,
+    _scroll_offset_x: f32,
+    scroll_offset_y: f32,
+) {
+    let line_height = (meta.font_size * 1.2).round() as f64;
+    let text_origin_y = if meta.multiline {
+        meta.taffy_y + meta.top_pad as f64 - scroll_offset_y as f64
+    } else {
+        meta.taffy_y + ((meta.input_height as f64 - line_height) / 2.0).max(0.0)
+    };
+    let caret_x = meta.taffy_x + meta.input_padding as f64 + cursor_rect.x0;
+    let line_left_x = meta.taffy_x + meta.input_padding as f64;
+    let line_top_y = text_origin_y + cursor_rect.y0;
+    let line_right_x = meta.taffy_x + meta.input_padding as f64 + meta.input_width as f64;
+    let area_x = (caret_x - 4.0).max(line_left_x);
+    let area_width = (line_right_x - area_x).clamp(24.0, meta.input_width as f64);
+    let position = winit::dpi::LogicalPosition::new(area_x, line_top_y);
+    let size = winit::dpi::LogicalSize::new(area_width as f32, line_height.max(1.0) as f32);
+    handle.winit_window.set_ime_cursor_area(position, size);
+}
+
+pub fn update_ime_cursor_area(dom: &mut UIState, handle: &mut Window) {
+    let Some(focused_id) = dom.focused_node else {
+        return;
+    };
+    let Some(meta) = focused_input_layout_meta(dom, focused_id) else {
+        return;
+    };
+    let Some((cursor_rect, scroll_offset_x, scroll_offset_y)) =
+        sync_focused_input_cursor(dom, handle, focused_id, &meta)
+    else {
+        return;
+    };
+    set_ime_cursor_area(
+        handle,
+        &meta,
+        &cursor_rect,
+        scroll_offset_x,
+        scroll_offset_y,
+    );
+}
+
 /// Scroll the focused input so the cursor stays visible.
 /// Call this after any action that moves the cursor (key press, click, drag).
 pub fn scroll_input_to_cursor(dom: &mut UIState, handle: &mut Window) {
     let Some(focused_id) = dom.focused_node else {
         return;
     };
-    let scroll_info = dom.nodes.get(focused_id).and_then(|node| {
-        node.as_text_input().map(|is| {
-            let display_text = is.display_text();
-            let font_size = node.style.text.font_size;
-            let padding = node.style.padding.left;
-            let input_padding = if padding > 0.0 { padding } else { 8.0 };
-            let pt = node.style.padding.top;
-            let top_pad = if pt > 0.0 { pt } else { 4.0 };
-            let cursor_pos = is.range().active;
-            let taffy_node = node.taffy_node;
-            let multiline = is.multiline;
-            (
-                display_text,
-                font_size,
-                input_padding,
-                top_pad,
-                cursor_pos,
-                taffy_node,
-                multiline,
-            )
-        })
-    });
-    let Some((display_text, font_size, input_padding, top_pad, cursor_pos, taffy_node, multiline)) =
-        scroll_info
-    else {
+    let Some(meta) = focused_input_layout_meta(dom, focused_id) else {
         return;
     };
 
-    let (input_width, input_height) = dom
-        .taffy
-        .layout(taffy_node)
-        .map(|l| (l.size.width - input_padding * 2.0, l.size.height))
-        .unwrap_or((200.0, 100.0));
-
-    if multiline {
-        let positions =
-            handle
-                .text_renderer
-                .grapheme_positions_2d(&display_text, font_size, Some(input_width));
-        let cursor_y = if cursor_pos < positions.len() {
-            positions[cursor_pos].y
+    if let Some(node) = dom.nodes.get_mut(focused_id)
+        && let Some(is) = node.as_text_input_mut()
+    {
+        is.set_font_size(meta.font_size);
+        if meta.multiline {
+            is.set_width(Some(meta.input_width));
         } else {
-            positions.last().map(|p| p.y).unwrap_or(0.0)
-        };
-        let line_height = (font_size * 1.2).round();
-        if let Some(node) = dom.nodes.get_mut(focused_id)
-            && let Some(is) = node.as_text_input_mut()
-        {
-            is.update_scroll_y(cursor_y, line_height, input_height - top_pad * 2.0);
+            is.set_width(None);
         }
-    } else {
-        let positions = handle
-            .text_renderer
-            .grapheme_x_positions(&display_text, font_size);
-        let cursor_x = if cursor_pos < positions.len() {
-            positions[cursor_pos]
-        } else {
-            positions.last().copied().unwrap_or(0.0)
-        };
-        if let Some(node) = dom.nodes.get_mut(focused_id)
-            && let Some(is) = node.as_text_input_mut()
-        {
-            is.update_scroll(cursor_x, input_width);
+        is.refresh_layout(&mut handle.text_renderer);
+        let cursor_rect = is.display_cursor_geometry(1.5, &mut handle.text_renderer);
+        if let Some(rect) = cursor_rect {
+            if meta.multiline {
+                let line_height = (meta.font_size * 1.2).round();
+                is.update_scroll_y(
+                    rect.y0 as f32,
+                    line_height,
+                    meta.input_height - meta.top_pad * 2.0,
+                );
+            } else {
+                is.update_scroll(rect.x0 as f32, meta.input_width);
+            }
         }
     }
-}
 
-// ── Cursor moved ─────────────────────────────────────────────────────
+    if let Some((cursor_rect, scroll_offset_x, scroll_offset_y)) =
+        sync_focused_input_cursor(dom, handle, focused_id, &meta)
+    {
+        set_ime_cursor_area(
+            handle,
+            &meta,
+            &cursor_rect,
+            scroll_offset_x,
+            scroll_offset_y,
+        );
+    }
+}
 
 pub fn handle_cursor_moved(
     dom: &mut UIState,
@@ -216,83 +288,47 @@ pub fn handle_cursor_moved(
     // Input drag selection
     if mouse_buttons & 1 != 0 {
         if let Some(drag_nid) = dom.dragging_input {
-            let cursor_info = dom.nodes.get(drag_nid).and_then(|node| {
-                node.as_text_input().map(|is| {
-                    let display_text = is.display_text();
-                    let font_size = node.style.text.font_size;
-                    let scroll_offset = is.scroll_offset;
-                    let scroll_offset_y = is.scroll_offset_y;
-                    let is_multiline = is.multiline;
-                    let padding = node.style.padding.left as f64;
-                    let input_padding = if padding > 0.0 { padding } else { 8.0 };
-                    let pad_top = node.style.padding.top;
-                    let top_pad = if pad_top > 0.0 { pad_top } else { 4.0 };
-                    let hitbox_bounds = node
-                        .interactivity
-                        .hitbox_id
-                        .and_then(|hid| dom.hitbox_store.get(hid))
-                        .map(|hb| hb.bounds);
-                    let taffy_node = node.taffy_node;
-                    (
-                        display_text,
-                        font_size,
-                        scroll_offset,
-                        scroll_offset_y,
-                        is_multiline,
-                        input_padding,
-                        top_pad,
-                        hitbox_bounds,
-                        taffy_node,
-                    )
-                })
+            let hit_info = dom.nodes.get(drag_nid).and_then(|node| {
+                let is = node.as_text_input()?;
+                let padding = node.style.padding.left as f64;
+                let input_padding = if padding > 0.0 { padding } else { 8.0 };
+                let pad_top = node.style.padding.top;
+                let top_pad = if pad_top > 0.0 { pad_top } else { 4.0 };
+                let hb = node
+                    .interactivity
+                    .hitbox_id
+                    .and_then(|hid| dom.hitbox_store.get(hid))?
+                    .bounds;
+                Some((
+                    is.scroll_offset,
+                    is.scroll_offset_y,
+                    is.multiline,
+                    input_padding,
+                    top_pad,
+                    hb,
+                ))
             });
 
-            // TODO  oh my gaaah TT please refactor this
             if let Some((
-                display_text,
-                font_size,
                 scroll_offset,
                 scroll_offset_y,
                 is_multiline,
                 input_padding,
                 top_pad,
-                Some(hb),
-                taffy_node,
-            )) = cursor_info
+                hb,
+            )) = hit_info
             {
-                let grapheme_idx = if !display_text.is_empty() {
-                    if is_multiline {
-                        let wrap_width = dom
-                            .taffy
-                            .layout(taffy_node)
-                            .map(|l| l.size.width - input_padding as f32 * 2.0)
-                            .unwrap_or(200.0);
-                        let relative_x = (logical_x - hb.x - input_padding) as f32;
-                        let relative_y = (logical_y - hb.y) as f32 + scroll_offset_y - top_pad;
-                        handle.text_renderer.hit_to_grapheme_2d(
-                            &display_text,
-                            font_size,
-                            Some(wrap_width),
-                            relative_x,
-                            relative_y,
-                        )
-                    } else {
-                        let relative_x = (logical_x - hb.x - input_padding) as f32 + scroll_offset;
-                        handle
-                            .text_renderer
-                            .hit_to_grapheme(&display_text, font_size, relative_x)
-                    }
+                let relative_x = if is_multiline {
+                    (logical_x - hb.x - input_padding) as f32
                 } else {
-                    0
+                    (logical_x - hb.x - input_padding) as f32 + scroll_offset
                 };
+                let relative_y = (logical_y - hb.y) as f32 + scroll_offset_y - top_pad;
 
                 if let Some(node) = dom.nodes.get_mut(drag_nid)
                     && let Some(is) = node.as_text_input_mut()
                 {
-                    is.update_range(|range| {
-                        range.active = grapheme_idx;
-                    });
-                    is.reset_blink();
+                    is.extend_selection_to_point(relative_x, relative_y, &mut handle.text_renderer);
                 }
                 scroll_input_to_cursor(dom, handle);
                 needs_redraw = true;
@@ -588,102 +624,55 @@ pub fn handle_mouse_input(
                     }
 
                     // Place cursor at click position
-                    let cursor_info = {
+                    let click_info = {
                         let node = &dom.nodes[nid];
                         let is = node.as_text_input().unwrap();
-                        let display_text = is.display_text();
-                        let font_size = node.style.text.font_size;
-                        let scroll_offset = is.scroll_offset;
-                        let scroll_offset_y = is.scroll_offset_y;
-                        let is_multiline = is.multiline;
                         let padding = node.style.padding.left as f64;
                         let input_padding = if padding > 0.0 { padding } else { 8.0 };
                         let pad_top = node.style.padding.top;
                         let top_pad = if pad_top > 0.0 { pad_top } else { 4.0 };
-                        let hitbox_bounds = node
+                        let hb = node
                             .interactivity
                             .hitbox_id
                             .and_then(|hid| dom.hitbox_store.get(hid))
                             .map(|hb| hb.bounds);
-                        let taffy_node = node.taffy_node;
                         (
-                            display_text,
-                            font_size,
-                            scroll_offset,
-                            scroll_offset_y,
-                            is_multiline,
+                            is.scroll_offset,
+                            is.scroll_offset_y,
+                            is.multiline,
                             input_padding,
                             top_pad,
-                            hitbox_bounds,
-                            taffy_node,
+                            hb,
                         )
                     };
                     let (
-                        display_text,
-                        font_size,
                         scroll_offset,
                         scroll_offset_y,
                         is_multiline,
                         input_padding,
                         top_pad,
                         hitbox_bounds,
-                        taffy_node,
-                    ) = cursor_info;
+                    ) = click_info;
 
                     if let Some(hb) = hitbox_bounds {
-                        let grapheme_idx = if !display_text.is_empty() {
-                            if is_multiline {
-                                let wrap_width = dom
-                                    .taffy
-                                    .layout(taffy_node)
-                                    .map(|l| l.size.width - input_padding as f32 * 2.0)
-                                    .unwrap_or(200.0);
-                                let relative_x = (mx - hb.x - input_padding) as f32;
-                                let relative_y = (my - hb.y) as f32 + scroll_offset_y - top_pad;
-                                handle.text_renderer.hit_to_grapheme_2d(
-                                    &display_text,
-                                    font_size,
-                                    Some(wrap_width),
-                                    relative_x,
-                                    relative_y,
-                                )
-                            } else {
-                                let relative_x = (mx - hb.x - input_padding) as f32 + scroll_offset;
-                                handle.text_renderer.hit_to_grapheme(
-                                    &display_text,
-                                    font_size,
-                                    relative_x,
-                                )
-                            }
+                        let relative_x = if is_multiline {
+                            (mx - hb.x - input_padding) as f32
                         } else {
-                            0
+                            (mx - hb.x - input_padding) as f32 + scroll_offset
                         };
+                        let relative_y = (my - hb.y) as f32 + scroll_offset_y - top_pad;
 
-                        // Focus the input (clears view selection, blurs previous input).
                         dom.focus_input(nid);
 
                         if let Some(node) = dom.nodes.get_mut(nid)
                             && let Some(is) = node.as_text_input_mut()
                         {
+                            let renderer = &mut handle.text_renderer;
                             match dom.click_count {
-                                2 => {
-                                    // Double-click: select word
-                                    let (ws, we) = is.word_at(grapheme_idx);
-                                    is.set_selection(ws, we);
-                                }
-                                3 => {
-                                    // Triple-click: select line/paragraph
-                                    let (ls, le) = is.line_at(grapheme_idx);
-                                    is.set_selection(ls, le);
-                                }
-                                4 => {
-                                    // Quad-click: select all
-                                    is.select_all();
-                                }
-                                _ => {
-                                    // Single click: place cursor
-                                    is.set_cursor(grapheme_idx);
-                                }
+                                2 => is.select_word_at_point(relative_x, relative_y, renderer),
+                                3 => is.select_line_at_point(relative_x, relative_y, renderer),
+                                4 => is.select_all(renderer),
+                                _ => is.move_to_point(relative_x, relative_y, renderer),
                             }
                             is.reset_blink();
                         }
@@ -924,71 +913,46 @@ pub fn handle_key_for_input(
         .with_focused_node(|node, focused_id| {
             let mut new_focus = Some(focused_id);
 
-            let shift = modifiers & 4 != 0;
-
-            // Handle ArrowUp/ArrowDown externally (vertical nav)
-            let is_vertical_nav = matches!(
-                key_event.logical_key,
-                Key::Named(NamedKey::ArrowUp) | Key::Named(NamedKey::ArrowDown)
-            );
-
-            if is_vertical_nav {
-                let is_up = key_event.logical_key == Key::Named(NamedKey::ArrowUp);
-                let extend = shift;
-
-                if let Some(is) = node.as_text_input_mut() {
-                    let (_, cur_col) = is.cursor_rowcol();
-                    let sticky = is.sticky_col.unwrap_or(cur_col);
-                    if is_up {
-                        is.move_up(extend, Some(sticky));
-                    } else {
-                        is.move_down(extend, Some(sticky));
+            if let Some(input_state) = node.as_text_input_mut() {
+                let result = input_state.handle_key(
+                    &key_event.logical_key,
+                    modifiers,
+                    &mut handle.text_renderer,
+                );
+                match result {
+                    KeyResult::Edit(edit) => {
+                        let value = input_state.text();
+                        let input_type = match edit.kind {
+                            input::EditKind::Insert => "insertText",
+                            input::EditKind::InsertFromPaste => "insertFromPaste",
+                            input::EditKind::DeleteBackward => "deleteContentBackward",
+                            input::EditKind::DeleteForward => "deleteContentForward",
+                            input::EditKind::DeleteWordBackward => "deleteWordBackward",
+                            input::EditKind::DeleteWordForward => "deleteWordForward",
+                            input::EditKind::DeleteByCut => "deleteByCut",
+                        };
+                        events.push(AppEvent::Input(InputEventData {
+                            window_id: wid,
+                            node_id: focused_id,
+                            value,
+                            input_type: input_type.to_string(),
+                            data: edit.inserted,
+                        }));
+                        needs_redraw = true;
                     }
-                    is.sticky_col = Some(sticky);
-                    is.sticky_x = None;
-                    is.reset_blink();
-                }
-
-                needs_redraw = true;
-            } else {
-                // Non-vertical key: delegate to InputState::handle_key
-                if let Some(input_state) = node.as_text_input_mut() {
-                    let result = input_state.handle_key(&key_event.logical_key, modifiers);
-                    match result {
-                        KeyResult::Edit(edit) => {
-                            let value = input_state.model.text();
-                            let input_type = match edit.kind {
-                                input::EditKind::Insert => "insertText",
-                                input::EditKind::InsertFromPaste => "insertFromPaste",
-                                input::EditKind::DeleteBackward => "deleteContentBackward",
-                                input::EditKind::DeleteForward => "deleteContentForward",
-                                input::EditKind::DeleteWordBackward => "deleteWordBackward",
-                                input::EditKind::DeleteWordForward => "deleteWordForward",
-                                input::EditKind::DeleteByCut => "deleteByCut",
-                            };
-                            events.push(AppEvent::Input(InputEventData {
-                                window_id: wid,
-                                node_id: focused_id,
-                                value,
-                                input_type: input_type.to_string(),
-                                data: edit.inserted,
-                            }));
-                            needs_redraw = true;
-                        }
-                        KeyResult::Blur => {
-                            input_state.focused = false;
-                            new_focus = None;
-                            events.push(AppEvent::Blur(FocusEventData {
-                                window_id: wid,
-                                node_id: focused_id,
-                            }));
-                            needs_redraw = true;
-                        }
-                        KeyResult::Handled => {
-                            needs_redraw = true;
-                        }
-                        KeyResult::Ignored => {}
+                    KeyResult::Blur => {
+                        input_state.focused = false;
+                        new_focus = None;
+                        events.push(AppEvent::Blur(FocusEventData {
+                            window_id: wid,
+                            node_id: focused_id,
+                        }));
+                        needs_redraw = true;
                     }
+                    KeyResult::Handled => {
+                        needs_redraw = true;
+                    }
+                    KeyResult::Ignored => {}
                 }
             }
             new_focus
@@ -1078,8 +1042,6 @@ pub fn handle_key_for_view_selection(
         _ => false,
     }
 }
-
-// ── Clipboard command pipeline ──────────────────────────────────────
 
 /// Identifies the target of a clipboard operation.
 pub enum ClipboardTarget {
@@ -1281,6 +1243,7 @@ pub fn apply_clipboard_command(
     dom: &mut UIState,
     wid: u32,
     clipboard: &mut SystemClipboard,
+    text_renderer: &mut crate::text::TextRenderer,
 ) -> (bool, Vec<AppEvent>) {
     let mut events = Vec::new();
     let mut needs_redraw = false;
@@ -1303,9 +1266,9 @@ pub fn apply_clipboard_command(
                 && let Some(target_id) = target
                 && let Some(node) = dom.nodes.get_mut(target_id)
                 && let Some(is) = node.as_text_input_mut()
-                && let Some((_cut_text, _edit)) = is.cut_selected_text()
+                && let Some((_cut_text, _edit)) = is.cut_selected_text(text_renderer)
             {
-                let value = is.model.text();
+                let value = is.text();
                 events.push(AppEvent::Input(InputEventData {
                     window_id: wid,
                     node_id: target_id,
@@ -1326,9 +1289,9 @@ pub fn apply_clipboard_command(
                 && let (Some(target_id), Some(text)) = (target, clipboard_text)
                 && let Some(node) = dom.nodes.get_mut(target_id)
                 && let Some(is) = node.as_text_input_mut()
-                && let Some(_edit) = is.paste_text(&text)
+                && let Some(_edit) = is.paste_text(&text, text_renderer)
             {
-                let value = is.model.text();
+                let value = is.text();
                 events.push(AppEvent::Input(InputEventData {
                     window_id: wid,
                     node_id: target_id,
@@ -1418,7 +1381,7 @@ fn next_word_boundary_in_run(
     i
 }
 
-pub fn handle_mouse_wheel(dom: &mut UIState, scroll_delta_y: f64) -> bool {
+pub fn handle_mouse_wheel(dom: &mut UIState, handle: &mut Window, scroll_delta_y: f64) -> bool {
     let mut needs_redraw = false;
     let Some((mx, my)) = dom.hit_state.mouse_position else {
         return false;
@@ -1473,6 +1436,10 @@ pub fn handle_mouse_wheel(dom: &mut UIState, scroll_delta_y: f64) -> bool {
             }
             needs_redraw = true;
         }
+    }
+
+    if needs_redraw {
+        update_ime_cursor_area(dom, handle);
     }
 
     needs_redraw

--- a/crates/uzumaki/src/input.rs
+++ b/crates/uzumaki/src/input.rs
@@ -1,7 +1,9 @@
 use std::time::Instant;
+
+use parley::PlainEditor;
 use winit::keyboard::{Key, NamedKey};
 
-use crate::{selection::SelectionRange, text_model::TextModel};
+use crate::text::{TextBrush, TextRenderer};
 
 #[derive(Clone, Debug)]
 pub enum EditKind {
@@ -27,23 +29,25 @@ pub enum KeyResult {
     Ignored,
 }
 
-// todo use parley editor
 pub struct InputState {
-    pub model: TextModel,
-    range: SelectionRange,
+    pub editor: PlainEditor<TextBrush>,
     pub placeholder: String,
     pub scroll_offset: f32,
     pub scroll_offset_y: f32,
     pub focused: bool,
-    // we should move this out from here
     pub blink_reset: Instant,
     pub disabled: bool,
     pub secure: bool,
     pub multiline: bool,
-    /// Preserved column for vertical navigation (sticky column in grapheme units).
-    pub sticky_col: Option<usize>,
-    /// Preserved X coordinate for vertical navigation.
-    pub sticky_x: Option<f32>,
+    pub max_length: Option<usize>,
+    pub font_size: f32,
+    pub preedit: Option<PreeditState>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PreeditState {
+    pub text: String,
+    pub cursor: Option<(usize, usize)>,
 }
 
 impl Default for InputState {
@@ -55,8 +59,7 @@ impl Default for InputState {
 impl InputState {
     pub fn new() -> Self {
         Self {
-            model: TextModel::new(),
-            range: SelectionRange::default(),
+            editor: PlainEditor::new(16.0),
             placeholder: String::new(),
             scroll_offset: 0.0,
             scroll_offset_y: 0.0,
@@ -65,8 +68,9 @@ impl InputState {
             disabled: false,
             secure: false,
             multiline: true,
-            sticky_col: None,
-            sticky_x: None,
+            max_length: None,
+            font_size: 16.0,
+            preedit: None,
         }
     }
 
@@ -76,104 +80,135 @@ impl InputState {
         this
     }
 
-    pub fn range(&self) -> SelectionRange {
-        self.range
+    pub fn text(&self) -> String {
+        self.editor.text().to_string()
     }
 
-    pub fn update_range<R>(&mut self, update: impl FnOnce(&mut SelectionRange) -> R) -> R {
-        update(&mut self.range)
-    }
-
-    #[inline]
-    fn set_range(&mut self, range: SelectionRange) {
-        self.range = range;
-    }
-
-    pub fn set_cursor(&mut self, pos: usize) {
-        self.range.set_cursor(pos);
-    }
-
-    /// Delete the current selection. Returns true if something was deleted.
-    fn delete_selection(&mut self) -> bool {
-        if self.range.is_collapsed() {
-            return false;
+    pub fn display_text(&self) -> String {
+        if self.secure {
+            "\u{2022}".repeat(self.editor.raw_text().chars().count())
+        } else {
+            self.editor.raw_text().to_string()
         }
-        let start = self.range.start();
-        let end = self.range.end();
-        self.model.delete_range(start, end);
-        self.range.set_cursor(start);
-        true
-    }
-
-    /// Get the selected text.
-    pub fn selected_text(&self) -> String {
-        let range = self.range();
-        if range.is_collapsed() {
-            return String::new();
-        }
-        self.model.text_in_range(range.start(), range.end())
-    }
-
-    pub fn text_content(&self) -> String {
-        self.model.text()
     }
 
     pub fn has_selection(&self) -> bool {
-        !self.range().is_collapsed()
+        !self.editor.raw_selection().is_collapsed()
     }
 
-    /// Insert text for a paste operation. Replaces selection if non-collapsed.
-    pub fn paste_text(&mut self, text: &str) -> Option<EditEvent> {
-        self.sticky_x = None;
-        self.sticky_col = None;
+    pub fn selected_text(&self) -> String {
+        self.editor
+            .selected_text()
+            .map(|s| s.to_string())
+            .unwrap_or_default()
+    }
+
+    fn with_driver(
+        &mut self,
+        renderer: &mut TextRenderer,
+        f: impl FnOnce(&mut parley::PlainEditorDriver<'_, TextBrush>),
+    ) {
+        let mut driver = self
+            .editor
+            .driver(&mut renderer.font_ctx, &mut renderer.layout_ctx);
+        f(&mut driver);
+    }
+
+    fn text_changed(&self, old_gen: parley::Generation) -> bool {
+        self.editor.generation() != old_gen
+    }
+
+    pub fn insert_text(&mut self, text: &str, renderer: &mut TextRenderer) -> Option<EditEvent> {
         if self.disabled {
             return None;
         }
-        let text_to_insert;
         let input = if !self.multiline {
-            text_to_insert = text
-                .chars()
-                .filter(|&c| c != '\n' && c != '\r')
-                .collect::<String>();
-            if text_to_insert.is_empty() {
+            let filtered: String = text.chars().filter(|&c| c != '\n' && c != '\r').collect();
+            if filtered.is_empty() {
                 return None;
             }
-            text_to_insert.as_str()
+            filtered
         } else {
-            text
+            text.to_string()
         };
 
-        self.delete_selection();
-
-        let range = self.range();
-        let pos = range.active;
-
-        match self.model.insert(pos, input, 0) {
-            Some(new_pos) => {
-                self.set_cursor(new_pos);
-                self.reset_blink();
-                Some(EditEvent {
-                    kind: EditKind::InsertFromPaste,
-                    inserted: Some(input.to_string()),
-                })
+        if let Some(max) = self.max_length {
+            let current = self.editor.raw_text().chars().count()
+                - self
+                    .editor
+                    .selected_text()
+                    .map(|s| s.chars().count())
+                    .unwrap_or(0);
+            let insert_count = input.chars().count();
+            if current + insert_count > max {
+                return None;
             }
-            None => None,
+        }
+
+        let generation = self.editor.generation();
+        self.with_driver(renderer, |d| d.insert_or_replace_selection(&input));
+        if self.text_changed(generation) {
+            self.reset_blink();
+            Some(EditEvent {
+                kind: EditKind::Insert,
+                inserted: Some(input),
+            })
+        } else {
+            None
         }
     }
 
-    /// Delete selected text for a cut operation. Returns the deleted text.
-    pub fn cut_selected_text(&mut self) -> Option<(String, EditEvent)> {
-        self.sticky_x = None;
-        self.sticky_col = None;
+    pub fn paste_text(&mut self, text: &str, renderer: &mut TextRenderer) -> Option<EditEvent> {
         if self.disabled {
             return None;
         }
-        let range = self.range();
-        if range.is_collapsed() {
+        let input = if !self.multiline {
+            let filtered: String = text.chars().filter(|&c| c != '\n' && c != '\r').collect();
+            if filtered.is_empty() {
+                return None;
+            }
+            filtered
+        } else {
+            text.to_string()
+        };
+
+        if let Some(max) = self.max_length {
+            let current = self.editor.raw_text().chars().count()
+                - self
+                    .editor
+                    .selected_text()
+                    .map(|s| s.chars().count())
+                    .unwrap_or(0);
+            if current + input.chars().count() > max {
+                return None;
+            }
+        }
+
+        let generation = self.editor.generation();
+        self.with_driver(renderer, |d| d.insert_or_replace_selection(&input));
+        if self.text_changed(generation) {
+            self.reset_blink();
+            Some(EditEvent {
+                kind: EditKind::InsertFromPaste,
+                inserted: Some(input),
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn cut_selected_text(
+        &mut self,
+        renderer: &mut TextRenderer,
+    ) -> Option<(String, EditEvent)> {
+        if self.disabled {
             return None;
         }
-        let text = self.model.text_in_range(range.start(), range.end());
-        self.delete_selection();
+        let text = self.selected_text();
+        if text.is_empty() {
+            return None;
+        }
+        self.with_driver(renderer, |d| d.delete_selection());
         self.reset_blink();
         Some((
             text,
@@ -184,376 +219,311 @@ impl InputState {
         ))
     }
 
-    pub fn insert_text(&mut self, text: &str) -> Option<EditEvent> {
-        self.sticky_x = None;
-        self.sticky_col = None;
+    pub fn delete_backward(&mut self, renderer: &mut TextRenderer) -> Option<EditEvent> {
         if self.disabled {
             return None;
         }
-        // Single-line: reject newlines
-        let text_to_insert;
-        let input = if !self.multiline {
-            text_to_insert = text
-                .chars()
-                .filter(|&c| c != '\n' && c != '\r')
-                .collect::<String>();
-            if text_to_insert.is_empty() {
-                return None;
-            }
-            text_to_insert.as_str()
-        } else {
-            text
-        };
-
-        self.delete_selection();
-
-        let range = self.range();
-        let pos = range.active;
-
-        match self.model.insert(pos, input, 0) {
-            Some(new_pos) => {
-                self.set_cursor(new_pos);
-
-                self.reset_blink();
-                Some(EditEvent {
-                    kind: EditKind::Insert,
-                    inserted: Some(input.to_string()),
-                })
-            }
-            None => None,
-        }
-    }
-
-    pub fn delete_backward(&mut self) -> Option<EditEvent> {
-        self.sticky_x = None;
-        self.sticky_col = None;
-        if self.disabled {
-            return None;
-        }
-        if self.delete_selection() {
+        let generation = self.editor.generation();
+        self.with_driver(renderer, |d| d.backdelete());
+        if self.text_changed(generation) {
             self.reset_blink();
-            return Some(EditEvent {
+            Some(EditEvent {
                 kind: EditKind::DeleteBackward,
                 inserted: None,
-            });
-        }
-
-        let range = self.range();
-
-        match self.model.delete_backward(range.active) {
-            Some(new_pos) => {
-                self.set_cursor(new_pos);
-                self.reset_blink();
-                Some(EditEvent {
-                    kind: EditKind::DeleteBackward,
-                    inserted: None,
-                })
-            }
-            None => None,
+            })
+        } else {
+            None
         }
     }
 
-    pub fn delete_forward(&mut self) -> Option<EditEvent> {
-        self.sticky_x = None;
-        self.sticky_col = None;
+    pub fn delete_forward(&mut self, renderer: &mut TextRenderer) -> Option<EditEvent> {
         if self.disabled {
             return None;
         }
-        if self.delete_selection() {
+        let generation = self.editor.generation();
+        self.with_driver(renderer, |d| d.delete());
+        if self.text_changed(generation) {
             self.reset_blink();
-            return Some(EditEvent {
+            Some(EditEvent {
                 kind: EditKind::DeleteForward,
                 inserted: None,
-            });
-        }
-        let range = self.range();
-        match self.model.delete_forward(range.active) {
-            Some(new_pos) => {
-                self.set_cursor(new_pos);
-                self.reset_blink();
-                Some(EditEvent {
-                    kind: EditKind::DeleteForward,
-                    inserted: None,
-                })
-            }
-            None => None,
+            })
+        } else {
+            None
         }
     }
 
-    pub fn delete_word_backward(&mut self) -> Option<EditEvent> {
-        self.sticky_x = None;
-        self.sticky_col = None;
+    pub fn delete_word_backward(&mut self, renderer: &mut TextRenderer) -> Option<EditEvent> {
         if self.disabled {
             return None;
         }
-        if self.delete_selection() {
+        let generation = self.editor.generation();
+        self.with_driver(renderer, |d| d.backdelete_word());
+        if self.text_changed(generation) {
             self.reset_blink();
-            return Some(EditEvent {
+            Some(EditEvent {
                 kind: EditKind::DeleteWordBackward,
                 inserted: None,
-            });
-        }
-        let range = self.range();
-        match self.model.delete_word_backward(range.active) {
-            Some(new_pos) => {
-                self.set_cursor(new_pos);
-                self.reset_blink();
-                Some(EditEvent {
-                    kind: EditKind::DeleteWordBackward,
-                    inserted: None,
-                })
-            }
-            None => None,
+            })
+        } else {
+            None
         }
     }
 
-    pub fn delete_word_forward(&mut self) -> Option<EditEvent> {
-        self.sticky_x = None;
-        self.sticky_col = None;
+    pub fn delete_word_forward(&mut self, renderer: &mut TextRenderer) -> Option<EditEvent> {
         if self.disabled {
             return None;
         }
-        if self.delete_selection() {
+        let generation = self.editor.generation();
+        self.with_driver(renderer, |d| d.delete_word());
+        if self.text_changed(generation) {
             self.reset_blink();
-            return Some(EditEvent {
+            Some(EditEvent {
                 kind: EditKind::DeleteWordForward,
                 inserted: None,
-            });
-        }
-
-        let range = self.range();
-        match self.model.delete_word_forward(range.active) {
-            Some(new_pos) => {
-                self.set_cursor(new_pos);
-                self.reset_blink();
-                Some(EditEvent {
-                    kind: EditKind::DeleteWordForward,
-                    inserted: None,
-                })
-            }
-            None => None,
+            })
+        } else {
+            None
         }
     }
 
-    // ── Movement ─────────────────────────────────────────────────────
-
-    pub fn move_left(&mut self, extend: bool) {
-        let mut range = self.range();
-        self.sticky_x = None;
-        if !extend && !range.is_collapsed() {
-            let pos = range.start();
-            range.set_cursor(pos);
-        } else if range.active > 0 {
-            range.active -= 1;
-            if !extend {
-                range.anchor = range.active;
-            }
+    pub fn move_left(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_left());
+        } else {
+            self.with_driver(renderer, |d| d.move_left());
         }
-
-        self.set_range(range);
         self.reset_blink();
     }
 
-    pub fn move_right(&mut self, extend: bool) {
-        let mut range = self.range();
-        self.sticky_x = None;
-        let count = self.model.grapheme_count();
-        if !extend && !range.is_collapsed() {
-            let pos = range.end();
-            range.set_cursor(pos);
-        } else if range.active < count {
-            range.active += 1;
-            if !extend {
-                range.anchor = range.active;
-            }
+    pub fn move_right(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_right());
+        } else {
+            self.with_driver(renderer, |d| d.move_right());
         }
-        self.set_range(range);
         self.reset_blink();
     }
 
-    pub fn move_word_left(&mut self, extend: bool) {
-        let mut range = self.range();
-        self.sticky_x = None;
-        let pos = self.model.find_word_start(range.active);
-        range.active = pos;
-        if !extend {
-            range.anchor = pos;
+    pub fn move_word_left(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_word_left());
+        } else {
+            self.with_driver(renderer, |d| d.move_word_left());
         }
-        self.set_range(range);
         self.reset_blink();
     }
 
-    pub fn move_word_right(&mut self, extend: bool) {
-        let mut range = self.range();
-        self.sticky_x = None;
-        let pos = self.model.find_word_end(range.active);
-        range.active = pos;
-        if !extend {
-            range.anchor = pos;
+    pub fn move_word_right(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_word_right());
+        } else {
+            self.with_driver(renderer, |d| d.move_word_right());
         }
-        self.set_range(range);
         self.reset_blink();
     }
 
-    pub fn move_home(&mut self, extend: bool) {
-        self.sticky_x = None;
-        let mut range = self.range();
-        let (row, _) = self.model.flat_to_rowcol(range.active);
-        let flat = self.model.rowcol_to_flat(row, 0);
-        range.active = flat;
-        if !extend {
-            range.anchor = flat;
+    pub fn move_up(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_up());
+        } else {
+            self.with_driver(renderer, |d| d.move_up());
         }
-        self.set_range(range);
+    }
+
+    pub fn move_down(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_down());
+        } else {
+            self.with_driver(renderer, |d| d.move_down());
+        }
+    }
+
+    pub fn move_home(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_to_line_start());
+        } else {
+            self.with_driver(renderer, |d| d.move_to_line_start());
+        }
         self.reset_blink();
     }
 
-    pub fn move_end(&mut self, extend: bool) {
-        self.sticky_x = None;
-        let mut range = self.range();
-        let (row, _) = self.model.flat_to_rowcol(range.active);
-        let line_len = self.model.line_grapheme_count(row);
-        let flat = self.model.rowcol_to_flat(row, line_len);
-        range.active = flat;
-        if !extend {
-            range.anchor = flat;
+    pub fn move_end(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_to_line_end());
+        } else {
+            self.with_driver(renderer, |d| d.move_to_line_end());
         }
-        self.set_range(range);
         self.reset_blink();
     }
 
-    pub fn move_absolute_home(&mut self, extend: bool) {
-        let mut range = self.range();
-        self.sticky_x = None;
-        range.active = 0;
-        if !extend {
-            range.anchor = 0;
+    pub fn move_absolute_home(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_to_text_start());
+        } else {
+            self.with_driver(renderer, |d| d.move_to_text_start());
         }
-        self.set_range(range);
         self.reset_blink();
     }
 
-    pub fn move_absolute_end(&mut self, extend: bool) {
-        self.sticky_x = None;
-        let mut range = self.range();
-
-        let count = self.model.grapheme_count();
-        range.active = count;
-        if !extend {
-            range.anchor = count;
+    pub fn move_absolute_end(&mut self, extend: bool, renderer: &mut TextRenderer) {
+        if extend {
+            self.with_driver(renderer, |d| d.select_to_text_end());
+        } else {
+            self.with_driver(renderer, |d| d.move_to_text_end());
         }
-
-        self.set_range(range);
         self.reset_blink();
     }
 
-    pub fn move_up(&mut self, extend: bool, sticky_col: Option<usize>) -> bool {
-        let mut range = self.range();
-        let (row, col) = self.model.flat_to_rowcol(range.active);
-        if row == 0 {
-            range.active = 0;
-            if !extend {
-                range.anchor = 0;
-            }
-            self.set_range(range);
-            return false;
-        }
-        let target_col = sticky_col.unwrap_or(col);
-        let prev_line_len = self.model.line_grapheme_count(row - 1);
-        let new_col = target_col.min(prev_line_len);
-        let flat = self.model.rowcol_to_flat(row - 1, new_col);
-        range.active = flat;
-        if !extend {
-            range.anchor = flat;
-        }
-        self.set_range(range);
-        true
-    }
-
-    pub fn move_down(&mut self, extend: bool, sticky_col: Option<usize>) -> bool {
-        let mut range = self.range();
-        let (row, col) = self.model.flat_to_rowcol(range.active);
-        if row >= self.model.line_count() - 1 {
-            let count = self.model.grapheme_count();
-            range.active = count;
-            if !extend {
-                range.anchor = count;
-            }
-            self.set_range(range);
-            return false;
-        }
-        let target_col = sticky_col.unwrap_or(col);
-        let next_line_len = self.model.line_grapheme_count(row + 1);
-        let new_col = target_col.min(next_line_len);
-        let flat = self.model.rowcol_to_flat(row + 1, new_col);
-        range.active = flat;
-        if !extend {
-            range.anchor = flat;
-        }
-        self.set_range(range);
-        true
-    }
-
-    pub fn move_to(&mut self, pos: usize, extend: bool) {
-        let mut range = self.range();
-        let count = self.model.grapheme_count();
-        range.active = pos.min(count);
-        if !extend {
-            range.anchor = range.active;
-        }
-        self.set_range(range);
+    pub fn move_to_point(&mut self, x: f32, y: f32, renderer: &mut TextRenderer) {
+        self.with_driver(renderer, |d| d.move_to_point(x, y));
         self.reset_blink();
     }
 
-    pub fn set_selection(&mut self, anchor: usize, active: usize) {
-        let mut range = self.range();
-        let max = self.grapheme_count();
-        range.anchor = anchor.min(max);
-        range.active = active.min(max);
-        self.set_range(range);
+    pub fn extend_selection_to_point(&mut self, x: f32, y: f32, renderer: &mut TextRenderer) {
+        self.with_driver(renderer, |d| d.extend_selection_to_point(x, y));
+    }
+
+    pub fn select_word_at_point(&mut self, x: f32, y: f32, renderer: &mut TextRenderer) {
+        self.with_driver(renderer, |d| d.select_word_at_point(x, y));
         self.reset_blink();
     }
 
-    pub fn select_all(&mut self) {
-        self.sticky_x = None;
-        let mut range = self.range();
-        range.anchor = 0;
-        range.active = self.model.grapheme_count();
-        self.set_range(range);
+    pub fn select_line_at_point(&mut self, x: f32, y: f32, renderer: &mut TextRenderer) {
+        self.with_driver(renderer, |d| d.select_line_at_point(x, y));
         self.reset_blink();
     }
 
-    pub fn word_at(&self, grapheme_idx: usize) -> (usize, usize) {
-        self.model.word_at(grapheme_idx)
+    pub fn select_all(&mut self, renderer: &mut TextRenderer) {
+        self.with_driver(renderer, |d| d.select_all());
+        self.reset_blink();
     }
 
-    pub fn line_at(&self, grapheme_idx: usize) -> (usize, usize) {
-        self.model.line_at(grapheme_idx)
-    }
-
-    pub fn set_value(&mut self, value: String) {
-        let mut range = self.range();
-        self.model.set_value(value);
-        let count = self.model.grapheme_count();
-        if range.active > count {
-            range.active = count;
+    pub fn set_preedit(&mut self, text: String, cursor: Option<(usize, usize)>) {
+        if text.is_empty() {
+            self.preedit = None;
+        } else {
+            self.preedit = Some(PreeditState { text, cursor });
         }
-        if range.anchor > count {
-            range.anchor = count;
+    }
+
+    pub fn clear_preedit(&mut self) {
+        self.preedit = None;
+    }
+
+    pub fn commit_ime_text(
+        &mut self,
+        text: &str,
+        renderer: &mut TextRenderer,
+    ) -> Option<EditEvent> {
+        self.preedit = None;
+        self.insert_text(text, renderer)
+    }
+
+    pub fn set_value(&mut self, value: &str) {
+        if self.editor.raw_text() != value {
+            self.editor.set_text(value);
         }
-        self.set_range(range);
     }
 
-    /// Current (row, col) of the active cursor position.
-    pub fn cursor_rowcol(&self) -> (usize, usize) {
-        self.model.flat_to_rowcol(self.range().active)
+    pub fn set_width(&mut self, width: Option<f32>) {
+        self.editor.set_width(width);
     }
 
-    pub fn grapheme_count(&self) -> usize {
-        self.model.grapheme_count()
+    pub fn set_scale(&mut self, scale: f32) {
+        self.editor.set_scale(scale);
     }
 
-    // ── Widget-layer concerns ────────────────────────────────────────
+    pub fn set_font_size(&mut self, font_size: f32) {
+        use parley::{LineHeight, StyleProperty};
+        self.font_size = font_size;
+        self.editor
+            .edit_styles()
+            .insert(StyleProperty::FontSize(font_size));
+        self.editor
+            .edit_styles()
+            .insert(StyleProperty::LineHeight(LineHeight::FontSizeRelative(1.2)));
+    }
+
+    pub fn refresh_layout(&mut self, renderer: &mut TextRenderer) {
+        self.editor
+            .refresh_layout(&mut renderer.font_ctx, &mut renderer.layout_ctx);
+    }
+
+    pub fn display_cursor_geometry(
+        &mut self,
+        width: f32,
+        renderer: &mut TextRenderer,
+    ) -> Option<parley::BoundingBox> {
+        if !self.secure {
+            return self.editor.cursor_geometry(width);
+        }
+        let sel = self.editor.raw_selection();
+        let byte_idx = sel.focus().index();
+        let char_count = self.editor.raw_text()[..byte_idx].chars().count();
+        let masked = "\u{2022}".repeat(char_count);
+        let font_size = self.font_size;
+        let x = renderer.grapheme_x_positions(&masked, font_size);
+        let cursor_x = *x.last().unwrap_or(&0.0);
+        let line_height = (font_size * 1.2).round();
+        Some(parley::BoundingBox {
+            x0: cursor_x as f64,
+            y0: 0.0,
+            x1: (cursor_x + width) as f64,
+            y1: line_height as f64,
+        })
+    }
+
+    pub fn display_selection_geometry(
+        &mut self,
+        renderer: &mut TextRenderer,
+    ) -> Vec<parley::BoundingBox> {
+        if !self.secure {
+            return self
+                .editor
+                .selection_geometry()
+                .into_iter()
+                .map(|(bb, _)| bb)
+                .collect();
+        }
+        let sel = self.editor.raw_selection();
+        if sel.is_collapsed() {
+            return vec![];
+        }
+        let text = self.editor.raw_text();
+        let anchor_chars = text[..sel.anchor().index()].chars().count();
+        let focus_chars = text[..sel.focus().index()].chars().count();
+        let (start, end) = if anchor_chars < focus_chars {
+            (anchor_chars, focus_chars)
+        } else {
+            (focus_chars, anchor_chars)
+        };
+        let full_masked = "\u{2022}".repeat(end);
+        let font_size = self.font_size;
+        let positions = renderer.grapheme_x_positions(&full_masked, font_size);
+        let x0 = if start < positions.len() {
+            positions[start]
+        } else {
+            0.0
+        };
+        let x1 = if end < positions.len() {
+            positions[end]
+        } else {
+            *positions.last().unwrap_or(&0.0)
+        };
+        let line_height = (font_size * 1.2).round();
+        vec![parley::BoundingBox {
+            x0: x0 as f64,
+            y0: 0.0,
+            x1: x1 as f64,
+            y1: line_height as f64,
+        }]
+    }
+
+    pub fn layout(&mut self, renderer: &mut TextRenderer) -> &parley::Layout<TextBrush> {
+        self.editor
+            .layout(&mut renderer.font_ctx, &mut renderer.layout_ctx)
+    }
 
     pub fn reset_blink(&mut self) {
         self.blink_reset = Instant::now();
@@ -565,14 +535,6 @@ impl InputState {
         }
         let elapsed = self.blink_reset.elapsed().as_millis();
         (elapsed % 1060) < 530
-    }
-
-    pub fn display_text(&self) -> String {
-        if self.secure {
-            "\u{2022}".repeat(self.model.grapheme_count())
-        } else {
-            self.model.text()
-        }
     }
 
     pub fn update_scroll(&mut self, cursor_x: f32, visible_width: f32) {
@@ -604,18 +566,18 @@ impl InputState {
         }
     }
 
-    // ── Key handling ─────────────────────────────────────────────────
-
-    pub fn handle_key(&mut self, key: &Key, modifiers: u32) -> KeyResult {
+    pub fn handle_key(
+        &mut self,
+        key: &Key,
+        modifiers: u32,
+        renderer: &mut TextRenderer,
+    ) -> KeyResult {
         if self.disabled {
             return KeyResult::Ignored;
         }
-        // Single-line: reject Enter
         if !self.multiline && matches!(key, Key::Named(NamedKey::Enter)) {
             return KeyResult::Ignored;
         }
-        self.sticky_x = None;
-        self.sticky_col = None;
 
         let shift = modifiers & 4 != 0;
         let ctrl = modifiers & 1 != 0;
@@ -624,12 +586,12 @@ impl InputState {
             Key::Character(ch) => {
                 if ctrl {
                     if ch.eq_ignore_ascii_case("a") {
-                        self.select_all();
+                        self.select_all(renderer);
                         return KeyResult::Handled;
                     }
                     return KeyResult::Ignored;
                 }
-                match self.insert_text(ch) {
+                match self.insert_text(ch, renderer) {
                     Some(edit) => KeyResult::Edit(edit),
                     None => KeyResult::Handled,
                 }
@@ -637,12 +599,12 @@ impl InputState {
             Key::Named(named) => match named {
                 NamedKey::Backspace => {
                     if ctrl {
-                        match self.delete_word_backward() {
+                        match self.delete_word_backward(renderer) {
                             Some(edit) => KeyResult::Edit(edit),
                             None => KeyResult::Handled,
                         }
                     } else {
-                        match self.delete_backward() {
+                        match self.delete_backward(renderer) {
                             Some(edit) => KeyResult::Edit(edit),
                             None => KeyResult::Handled,
                         }
@@ -650,12 +612,12 @@ impl InputState {
                 }
                 NamedKey::Delete => {
                     if ctrl {
-                        match self.delete_word_forward() {
+                        match self.delete_word_forward(renderer) {
                             Some(edit) => KeyResult::Edit(edit),
                             None => KeyResult::Handled,
                         }
                     } else {
-                        match self.delete_forward() {
+                        match self.delete_forward(renderer) {
                             Some(edit) => KeyResult::Edit(edit),
                             None => KeyResult::Handled,
                         }
@@ -663,47 +625,54 @@ impl InputState {
                 }
                 NamedKey::ArrowLeft => {
                     if ctrl {
-                        self.move_word_left(shift);
+                        self.move_word_left(shift, renderer);
                     } else {
-                        self.move_left(shift);
+                        self.move_left(shift, renderer);
                     }
                     KeyResult::Handled
                 }
                 NamedKey::ArrowRight => {
                     if ctrl {
-                        self.move_word_right(shift);
+                        self.move_word_right(shift, renderer);
                     } else {
-                        self.move_right(shift);
+                        self.move_right(shift, renderer);
                     }
                     KeyResult::Handled
                 }
-                NamedKey::ArrowUp | NamedKey::ArrowDown => KeyResult::Ignored,
+                NamedKey::ArrowUp => {
+                    self.move_up(shift, renderer);
+                    KeyResult::Handled
+                }
+                NamedKey::ArrowDown => {
+                    self.move_down(shift, renderer);
+                    KeyResult::Handled
+                }
                 NamedKey::Home => {
                     if ctrl {
-                        self.move_absolute_home(shift);
+                        self.move_absolute_home(shift, renderer);
                     } else {
-                        self.move_home(shift);
+                        self.move_home(shift, renderer);
                     }
                     KeyResult::Handled
                 }
                 NamedKey::End => {
                     if ctrl {
-                        self.move_absolute_end(shift);
+                        self.move_absolute_end(shift, renderer);
                     } else {
-                        self.move_end(shift);
+                        self.move_end(shift, renderer);
                     }
                     KeyResult::Handled
                 }
-                NamedKey::Space => match self.insert_text(" ") {
+                NamedKey::Space => match self.insert_text(" ", renderer) {
                     Some(edit) => KeyResult::Edit(edit),
                     None => KeyResult::Handled,
                 },
                 NamedKey::Escape => KeyResult::Blur,
-                NamedKey::Enter => match self.insert_text("\n") {
+                NamedKey::Enter => match self.insert_text("\n", renderer) {
                     Some(edit) => KeyResult::Edit(edit),
                     None => KeyResult::Ignored,
                 },
-                NamedKey::Tab => match self.insert_text("    ") {
+                NamedKey::Tab => match self.insert_text("    ", renderer) {
                     Some(edit) => KeyResult::Edit(edit),
                     None => KeyResult::Ignored,
                 },
@@ -717,1089 +686,192 @@ impl InputState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn input(text: &str) -> InputState {
-        let mut is = InputState::default();
-        is.set_value(text.to_string());
-        is
-    }
 
-    fn input_at(text: &str, cursor: usize) -> InputState {
-        let mut is = input(text);
-        is.set_cursor(cursor);
-        is
-    }
-
-    fn input_sel(text: &str, anchor: usize, active: usize) -> InputState {
-        let mut is = input(text);
-        is.set_range(SelectionRange::new(anchor, active));
-        is
+    fn make_renderer() -> TextRenderer {
+        TextRenderer::new()
     }
 
     #[test]
-    fn insert_text_basic() {
-        let mut is = InputState::default();
-        is.insert_text("hello");
-        assert_eq!(is.model.text(), "hello");
-        assert_eq!(is.range().active, 5);
-        assert!(is.range().is_collapsed());
+    fn new_input_has_empty_text() {
+        let is = InputState::new();
+        assert_eq!(is.text(), "");
+        assert!(!is.has_selection());
     }
 
     #[test]
-    fn insert_text_at_cursor() {
-        let mut is = input_at("hllo", 1);
-        is.insert_text("e");
-        assert_eq!(is.model.text(), "hello");
-        assert_eq!(is.range().active, 2);
+    fn insert_text_updates_content() {
+        let mut is = InputState::new();
+        let mut r = make_renderer();
+        is.insert_text("hello", &mut r);
+        assert_eq!(is.text(), "hello");
     }
 
     #[test]
-    fn insert_replaces_selection() {
-        let mut is = input_sel("hello world", 0, 5);
-        is.insert_text("goodbye");
-        assert_eq!(is.model.text(), "goodbye world");
-        assert_eq!(is.range().active, 7);
-        assert!(is.range().is_collapsed());
-    }
-
-    #[test]
-    fn insert_newline_in_single_line_mode() {
-        let mut is = input_at("hello", 5);
-        is.multiline = false;
-        let result = is.insert_text("\n");
-        assert!(result.is_none());
-        assert_eq!(is.model.text(), "hello");
-    }
-
-    #[test]
-    fn insert_newline_in_multiline_mode() {
-        let mut is = input_at("hello", 5);
-        // multiline is true by default
-        let result = is.insert_text("\n");
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "hello\n");
-    }
-
-    #[test]
-    fn insert_disabled_does_nothing() {
-        let mut is = input_at("hello", 5);
+    fn insert_text_disabled_is_noop() {
+        let mut is = InputState::new();
         is.disabled = true;
-        assert!(is.insert_text("!").is_none());
-        assert_eq!(is.model.text(), "hello");
+        let mut r = make_renderer();
+        let result = is.insert_text("hello", &mut r);
+        assert!(result.is_none());
+        assert_eq!(is.text(), "");
     }
 
     #[test]
-    fn delete_backward_at_end() {
-        let mut is = input_at("hello", 5);
-        let result = is.delete_backward();
+    fn single_line_strips_newlines() {
+        let mut is = InputState::new_single_line();
+        let mut r = make_renderer();
+        is.insert_text("a\nb\nc", &mut r);
+        assert_eq!(is.text(), "abc");
+    }
+
+    #[test]
+    fn max_length_rejects_overflow() {
+        let mut is = InputState::new();
+        is.max_length = Some(3);
+        let mut r = make_renderer();
+        is.insert_text("ab", &mut r);
+        let result = is.insert_text("cd", &mut r);
+        assert!(result.is_none());
+        assert_eq!(is.text(), "ab");
+    }
+
+    #[test]
+    fn max_length_allows_exact_fit() {
+        let mut is = InputState::new();
+        is.max_length = Some(3);
+        let mut r = make_renderer();
+        is.insert_text("ab", &mut r);
+        let result = is.insert_text("c", &mut r);
         assert!(result.is_some());
-        assert_eq!(is.model.text(), "hell");
-        assert_eq!(is.range().active, 4);
+        assert_eq!(is.text(), "abc");
     }
 
     #[test]
-    fn delete_backward_at_start() {
-        let mut is = input_at("hello", 0);
-        assert!(is.delete_backward().is_none());
-        assert_eq!(is.model.text(), "hello");
+    fn delete_backward_removes_char() {
+        let mut is = InputState::new();
+        let mut r = make_renderer();
+        is.insert_text("abc", &mut r);
+        is.delete_backward(&mut r);
+        assert_eq!(is.text(), "ab");
     }
 
     #[test]
-    fn delete_backward_with_selection() {
-        let mut is = input_sel("hello world", 5, 11);
-        let result = is.delete_backward();
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "hello");
-        assert_eq!(is.range().active, 5);
+    fn delete_forward_at_end_is_noop() {
+        let mut is = InputState::new();
+        let mut r = make_renderer();
+        is.insert_text("abc", &mut r);
+        is.delete_forward(&mut r);
+        assert_eq!(is.text(), "abc");
     }
 
     #[test]
-    fn delete_backward_joins_lines() {
-        let mut is = input_at("hello\nworld", 6);
-        is.multiline = true;
-        let result = is.delete_backward();
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "helloworld");
-        assert_eq!(is.range().active, 5);
+    fn select_all_and_cut() {
+        let mut is = InputState::new();
+        let mut r = make_renderer();
+        is.insert_text("hello", &mut r);
+        is.select_all(&mut r);
+        assert!(is.has_selection());
+        let cut = is.cut_selected_text(&mut r);
+        assert!(cut.is_some());
+        let (text, _) = cut.unwrap();
+        assert_eq!(text, "hello");
+        assert_eq!(is.text(), "");
     }
 
     #[test]
-    fn delete_forward_at_start() {
-        let mut is = input_at("hello", 0);
-        let result = is.delete_forward();
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "ello");
-        assert_eq!(is.range().active, 0);
+    fn paste_text_inserts() {
+        let mut is = InputState::new();
+        let mut r = make_renderer();
+        is.insert_text("ab", &mut r);
+        is.paste_text("cd", &mut r);
+        assert_eq!(is.text(), "abcd");
     }
 
     #[test]
-    fn delete_forward_at_end() {
-        let mut is = input_at("hello", 5);
-        assert!(is.delete_forward().is_none());
+    fn display_text_secure_masks() {
+        let mut is = InputState::new();
+        is.secure = true;
+        let mut r = make_renderer();
+        is.insert_text("pass", &mut r);
+        assert_eq!(is.display_text(), "\u{2022}\u{2022}\u{2022}\u{2022}");
+        assert_eq!(is.text(), "pass");
     }
 
     #[test]
-    fn delete_forward_with_selection() {
-        let mut is = input_sel("hello world", 0, 6);
-        let result = is.delete_forward();
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "world");
-        assert_eq!(is.range().active, 0);
-    }
-
-    #[test]
-    fn delete_forward_joins_lines() {
-        let mut is = input_at("hello\nworld", 5);
-        is.multiline = true;
-        let result = is.delete_forward();
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "helloworld");
-    }
-
-    #[test]
-    fn delete_word_backward_basic() {
-        let mut is = input_at("hello world", 11);
-        let result = is.delete_word_backward();
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "hello ");
-        assert_eq!(is.range().active, 6);
-    }
-
-    #[test]
-    fn delete_word_backward_at_start() {
-        let mut is = input_at("hello", 0);
-        assert!(is.delete_word_backward().is_none());
-    }
-
-    #[test]
-    fn delete_word_backward_with_selection() {
-        let mut is = input_sel("hello world", 6, 11);
-        let result = is.delete_word_backward();
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "hello ");
-        assert_eq!(is.range().active, 6);
-    }
-
-    #[test]
-    fn delete_word_forward_basic() {
-        let mut is = input_at("hello world", 0);
-        let result = is.delete_word_forward();
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "world");
-        assert_eq!(is.range().active, 0);
-    }
-
-    #[test]
-    fn delete_word_forward_at_end() {
-        let mut is = input_at("hello", 5);
-        assert!(is.delete_word_forward().is_none());
-    }
-
-    #[test]
-    fn move_left_basic() {
-        let mut is = input_at("hello", 3);
-        is.move_left(false);
-        assert_eq!(is.range().active, 2);
-        assert!(is.range().is_collapsed());
-    }
-
-    #[test]
-    fn move_left_collapses_selection() {
-        let mut is = input_sel("hello", 1, 4);
-        is.move_left(false);
-        assert_eq!(is.range().active, 1);
-        assert!(is.range().is_collapsed());
-    }
-
-    #[test]
-    fn move_left_extend() {
-        let mut is = input_at("hello", 3);
-        is.move_left(true);
-        assert_eq!(is.range().active, 2);
-        assert_eq!(is.range().anchor, 3);
-    }
-
-    #[test]
-    fn move_left_at_start() {
-        let mut is = input_at("hello", 0);
-        is.move_left(false);
-        assert_eq!(is.range().active, 0);
-    }
-
-    #[test]
-    fn move_right_basic() {
-        let mut is = input_at("hello", 3);
-        is.move_right(false);
-        assert_eq!(is.range().active, 4);
-        assert!(is.range().is_collapsed());
-    }
-
-    #[test]
-    fn move_right_collapses_selection() {
-        let mut is = input_sel("hello", 1, 4);
-        is.move_right(false);
-        assert_eq!(is.range().active, 4);
-        assert!(is.range().is_collapsed());
-    }
-
-    #[test]
-    fn move_right_extend() {
-        let mut is = input_at("hello", 3);
-        is.move_right(true);
-        assert_eq!(is.range().active, 4);
-        assert_eq!(is.range().anchor, 3);
-    }
-
-    #[test]
-    fn move_right_at_end() {
-        let mut is = input_at("hello", 5);
-        is.move_right(false);
-        assert_eq!(is.range().active, 5);
-    }
-
-    #[test]
-    fn move_right_across_newline() {
-        let mut is = input_at("ab\ncd", 2);
-        is.multiline = true;
-        is.move_right(false);
-        assert_eq!(is.range().active, 3);
-        assert_eq!(is.model.flat_to_rowcol(3), (1, 0));
-    }
-
-    #[test]
-    fn move_left_across_newline() {
-        let mut is = input_at("ab\ncd", 3);
-        is.multiline = true;
-        is.move_left(false);
-        assert_eq!(is.range().active, 2);
-        assert_eq!(is.model.flat_to_rowcol(2), (0, 2));
-    }
-
-    #[test]
-    fn move_word_left() {
-        let mut is = input_at("hello world foo", 15);
-        is.move_word_left(false);
-        assert_eq!(is.range().active, 12);
-        is.move_word_left(false);
-        assert_eq!(is.range().active, 6);
-        is.move_word_left(false);
-        assert_eq!(is.range().active, 0);
-    }
-
-    #[test]
-    fn move_word_right() {
-        let mut is = input_at("hello world foo", 0);
-        is.move_word_right(false);
-        assert_eq!(is.range().active, 6);
-        is.move_word_right(false);
-        assert_eq!(is.range().active, 12);
-        is.move_word_right(false);
-        assert_eq!(is.range().active, 15);
-    }
-
-    #[test]
-    fn move_word_left_with_extend() {
-        let mut is = input_at("hello world", 11);
-        is.move_word_left(true);
-        assert_eq!(is.range().active, 6);
-        assert_eq!(is.range().anchor, 11);
-    }
-
-    #[test]
-    fn move_home_single_line() {
-        let mut is = input_at("hello", 3);
-        is.move_home(false);
-        assert_eq!(is.range().active, 0);
-    }
-
-    #[test]
-    fn move_end_single_line() {
-        let mut is = input_at("hello", 2);
-        is.move_end(false);
-        assert_eq!(is.range().active, 5);
-    }
-
-    #[test]
-    fn move_home_on_second_line() {
-        let mut is = input_at("hello\nworld", 8);
-        is.multiline = true;
-        is.move_home(false);
-        assert_eq!(is.range().active, 6);
-    }
-
-    #[test]
-    fn move_end_on_first_line() {
-        let mut is = input_at("hello\nworld", 2);
-        is.multiline = true;
-        is.move_end(false);
-        assert_eq!(is.range().active, 5);
-    }
-
-    #[test]
-    fn move_home_end_each_line() {
-        let mut is = input_at("abc\ndef\nghi", 1);
-        is.multiline = true;
-
-        is.move_home(false);
-        assert_eq!(is.range().active, 0);
-        is.move_end(false);
-        assert_eq!(is.range().active, 3);
-
-        is.move_to(5, false);
-        is.move_home(false);
-        assert_eq!(is.range().active, 4);
-        is.move_end(false);
-        assert_eq!(is.range().active, 7);
-
-        is.move_to(9, false);
-        is.move_home(false);
-        assert_eq!(is.range().active, 8);
-        is.move_end(false);
-        assert_eq!(is.range().active, 11);
-    }
-
-    #[test]
-    fn move_absolute_home() {
-        let mut is = input_at("hello\nworld", 8);
-        is.move_absolute_home(false);
-        assert_eq!(is.range().active, 0);
-    }
-
-    #[test]
-    fn move_absolute_end() {
-        let mut is = input_at("hello\nworld", 2);
-        is.move_absolute_end(false);
-        assert_eq!(is.range().active, 11);
-    }
-
-    #[test]
-    fn move_up_basic() {
-        let mut is = input_at("hello\nworld", 8);
-        is.multiline = true;
-        let moved = is.move_up(false, None);
-        assert!(moved);
-        assert_eq!(is.range().active, 2);
-    }
-
-    #[test]
-    fn move_down_basic() {
-        let mut is = input_at("hello\nworld", 2);
-        is.multiline = true;
-        let moved = is.move_down(false, None);
-        assert!(moved);
-        assert_eq!(is.range().active, 8);
-    }
-
-    #[test]
-    fn move_up_from_first_line() {
-        let mut is = input_at("hello\nworld", 3);
-        let moved = is.move_up(false, None);
-        assert!(!moved);
-        assert_eq!(is.range().active, 0);
-    }
-
-    #[test]
-    fn move_down_from_last_line() {
-        let mut is = input_at("hello\nworld", 8);
-        let moved = is.move_down(false, None);
-        assert!(!moved);
-        assert_eq!(is.range().active, 11);
-    }
-
-    #[test]
-    fn move_up_down_preserves_sticky_col() {
-        let mut is = input_at("abcdef\nab\nabcdef", 5);
-        is.multiline = true;
-
-        let (_, col) = is.cursor_rowcol();
-        assert_eq!(col, 5);
-
-        is.move_down(false, Some(5));
-        assert_eq!(is.cursor_rowcol(), (1, 2));
-
-        is.move_down(false, Some(5));
-        assert_eq!(is.cursor_rowcol(), (2, 5));
-    }
-
-    #[test]
-    fn move_up_with_extend() {
-        let mut is = input_at("hello\nworld", 8);
-        is.multiline = true;
-        is.move_up(true, None);
-        assert_eq!(is.range().active, 2);
-        assert_eq!(is.range().anchor, 8);
-    }
-
-    #[test]
-    fn select_all_basic() {
-        let mut is = input("hello");
-        is.select_all();
-        assert_eq!(is.range().anchor, 0);
-        assert_eq!(is.range().active, 5);
-    }
-
-    #[test]
-    fn select_all_multiline() {
-        let mut is = input("hello\nworld");
-        is.select_all();
-        assert_eq!(is.range().anchor, 0);
-        assert_eq!(is.range().active, 11);
-        assert_eq!(is.selected_text(), "hello\nworld");
-    }
-
-    #[test]
-    fn selected_text_empty_when_collapsed() {
-        let is = input_at("hello", 3);
-        assert_eq!(is.selected_text(), "");
-    }
-
-    #[test]
-    fn selected_text_within_line() {
-        let is = input_sel("hello world", 0, 5);
-        assert_eq!(is.selected_text(), "hello");
-    }
-
-    #[test]
-    fn selected_text_across_lines() {
-        let is = input_sel("abc\ndef\nghi", 2, 6);
-        assert_eq!(is.selected_text(), "c\nde");
-    }
-
-    #[test]
-    fn selected_text_reversed_selection() {
-        let is = input_sel("hello world", 5, 0);
-        assert_eq!(is.selected_text(), "hello");
-    }
-
-    #[test]
-    fn move_to_basic() {
-        let mut is = input("hello");
-        is.move_to(3, false);
-        assert_eq!(is.range().active, 3);
-        assert!(is.range().is_collapsed());
-    }
-
-    #[test]
-    fn move_to_with_extend() {
-        let mut is = input_at("hello", 1);
-        is.move_to(4, true);
-        assert_eq!(is.range().active, 4);
-        assert_eq!(is.range().anchor, 1);
-    }
-
-    #[test]
-    fn move_to_clamps() {
-        let mut is = input("hello");
-        is.move_to(100, false);
-        assert_eq!(is.range().active, 5);
-    }
-
-    #[test]
-    fn word_at_basic() {
-        let is = input("hello world");
-        assert_eq!(is.word_at(0), (0, 5));
-        assert_eq!(is.word_at(7), (6, 11));
-    }
-
-    #[test]
-    fn set_value_clamps_selection() {
-        let mut is = input_at("hello world", 11);
-        is.set_value("hi".to_string());
-        assert_eq!(is.range().active, 2);
-        assert_eq!(is.range().anchor, 2);
-    }
-
-    #[test]
-    fn display_text_normal() {
-        let is = input("hello");
+    fn display_text_normal_shows_raw() {
+        let mut is = InputState::new();
+        let mut r = make_renderer();
+        is.insert_text("hello", &mut r);
         assert_eq!(is.display_text(), "hello");
     }
 
     #[test]
-    fn display_text_secure() {
-        let mut is = input("hello");
-        is.secure = true;
-        assert_eq!(
-            is.display_text(),
-            "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}"
-        );
+    fn set_value_replaces_content() {
+        let mut is = InputState::new();
+        let mut r = make_renderer();
+        is.insert_text("old", &mut r);
+        is.set_value("new");
+        assert_eq!(is.text(), "new");
     }
 
     #[test]
-    fn cursor_rowcol_basic() {
-        let is = input_at("hello\nworld", 8);
-        assert_eq!(is.cursor_rowcol(), (1, 2));
+    fn set_font_size_stores_value() {
+        let mut is = InputState::new();
+        assert_eq!(is.font_size, 16.0);
+        is.set_font_size(24.0);
+        assert_eq!(is.font_size, 24.0);
     }
 
     #[test]
-    fn disabled_blocks_all_edits() {
-        let mut is = input_at("hello", 5);
-        is.disabled = true;
-        assert!(is.insert_text("!").is_none());
-        assert!(is.delete_backward().is_none());
-        assert!(is.delete_forward().is_none());
-        assert!(is.delete_word_backward().is_none());
-        assert!(is.delete_word_forward().is_none());
-        assert_eq!(is.model.text(), "hello");
+    fn update_scroll_scrolls_right() {
+        let mut is = InputState::new();
+        is.scroll_offset = 0.0;
+        is.update_scroll(250.0, 200.0);
+        assert_eq!(is.scroll_offset, 50.0);
     }
 
     #[test]
-    fn delete_selection_multiline() {
-        let mut is = input_sel("abc\ndef\nghi", 2, 9);
-        is.multiline = true;
-        is.delete_backward();
-        assert_eq!(is.model.text(), "abhi");
-        assert_eq!(is.range().active, 2);
+    fn update_scroll_scrolls_left() {
+        let mut is = InputState::new();
+        is.scroll_offset = 100.0;
+        is.update_scroll(50.0, 200.0);
+        assert_eq!(is.scroll_offset, 50.0);
     }
 
     #[test]
-    fn integration_type_select_delete_type() {
-        let mut is = InputState::default();
-        is.insert_text("hello world");
-        assert_eq!(is.model.text(), "hello world");
-
-        // Select "world"
-        is.set_range(SelectionRange::new(6, 11));
-        is.insert_text("rust");
-        assert_eq!(is.model.text(), "hello rust");
-
-        // Move to start, delete forward
-        is.move_to(0, false);
-        is.delete_forward();
-        assert_eq!(is.model.text(), "ello rust");
+    fn update_scroll_no_negative() {
+        let mut is = InputState::new();
+        is.scroll_offset = -10.0;
+        is.update_scroll(50.0, 200.0);
+        assert!(is.scroll_offset >= 0.0);
     }
 
     #[test]
-    fn integration_multiline_editing() {
-        let mut is = InputState {
-            multiline: true,
-            ..Default::default()
-        };
-        is.insert_text("line1\nline2\nline3");
-        assert_eq!(is.model.text(), "line1\nline2\nline3");
-        assert_eq!(is.model.line_count(), 3);
-
-        // Cursor should be at end
-        assert_eq!(is.range().active, is.model.grapheme_count());
-
-        // Move up
-        let (_, col) = is.cursor_rowcol();
-        is.move_up(false, Some(col));
-        assert_eq!(is.cursor_rowcol(), (1, 5));
-
-        // Delete backward (delete "2")
-        is.delete_backward();
-        assert_eq!(is.model.text(), "line1\nline\nline3");
+    fn update_scroll_y_scrolls_down() {
+        let mut is = InputState::new();
+        is.scroll_offset_y = 0.0;
+        is.update_scroll_y(250.0, 20.0, 200.0);
+        assert_eq!(is.scroll_offset_y, 70.0);
     }
 
     #[test]
-    fn max_length_blocks_insert() {
-        let mut is = InputState::default();
-        is.model.max_length = Some(5);
-        is.insert_text("hello");
-        assert_eq!(is.model.text(), "hello");
-        assert!(is.insert_text("!").is_none());
-        assert_eq!(is.model.text(), "hello");
+    fn update_scroll_y_scrolls_up() {
+        let mut is = InputState::new();
+        is.scroll_offset_y = 100.0;
+        is.update_scroll_y(50.0, 20.0, 200.0);
+        assert_eq!(is.scroll_offset_y, 50.0);
     }
 
     #[test]
-    fn max_length_allows_replace_within_limit() {
-        let mut is = InputState::default();
-        is.model.max_length = Some(5);
-        is.insert_text("hello");
-        // Select all and replace with shorter text
-        is.select_all();
-        let result = is.insert_text("hi");
-        assert!(result.is_some());
-        assert_eq!(is.model.text(), "hi");
-    }
-
-    /// Type "hello world", press Enter to split into two lines, verify content.
-    #[test]
-    fn should_split_line_on_enter() {
-        let mut is = InputState {
-            multiline: true,
-            ..Default::default()
-        };
-
-        // Type "hello world"
-        is.insert_text("hello world");
-        assert_eq!(is.model.text(), "hello world");
-        assert_eq!(is.range().active, 11);
-
-        // Move cursor between "hello" and " world" (pos 5)
-        is.move_to(5, false);
-        assert_eq!(is.range().active, 5);
-
-        // Press Enter to split the line
-        is.insert_text("\n");
-        assert_eq!(is.model.text(), "hello\n world");
-        assert_eq!(is.model.line_count(), 2);
-        assert_eq!(is.cursor_rowcol(), (1, 0));
-    }
-
-    /// Type on line 1, Enter, type on line 2, move up, insert text on line 1.
-    #[test]
-    fn should_type_enter_move_up_and_insert() {
-        let mut is = InputState {
-            multiline: true,
-            ..Default::default()
-        };
-
-        is.insert_text("aaa");
-        is.insert_text("\n");
-        is.insert_text("bbb");
-        assert_eq!(is.model.text(), "aaa\nbbb");
-        assert_eq!(is.cursor_rowcol(), (1, 3));
-
-        // Move up — should land on row 0, col 3
-        let col = is.cursor_rowcol().1;
-        is.move_up(false, Some(col));
-        assert_eq!(is.cursor_rowcol(), (0, 3));
-
-        // Insert " hello" at end of line 1
-        is.insert_text(" hello");
-        assert_eq!(is.model.text(), "aaa hello\nbbb");
-        assert_eq!(is.cursor_rowcol(), (0, 9));
-    }
-
-    /// Type two lines, move up, move left twice, insert a character mid-line.
-    #[test]
-    fn should_move_up_left_and_insert_mid_line() {
-        let mut is = InputState {
-            multiline: true,
-            ..Default::default()
-        };
-
-        is.insert_text("abcd\nefgh");
-        assert_eq!(is.cursor_rowcol(), (1, 4));
-
-        // Move up → row 0, col 4 (end of "abcd")
-        let col = is.cursor_rowcol().1;
-        is.move_up(false, Some(col));
-        assert_eq!(is.cursor_rowcol(), (0, 4));
-
-        // Move left twice → col 2
-        is.move_left(false);
-        is.move_left(false);
-        assert_eq!(is.cursor_rowcol(), (0, 2));
-
-        // Insert "X"
-        is.insert_text("X");
-        assert_eq!(is.model.text(), "abXcd\nefgh");
-        assert_eq!(is.cursor_rowcol(), (0, 3));
-    }
-
-    /// Split a line in the middle: "helloworld" → Enter at pos 5 → "hello\nworld".
-    #[test]
-    fn should_split_line_in_middle_and_continue_typing() {
-        let mut is = InputState {
-            multiline: true,
-            ..Default::default()
-        };
-
-        is.insert_text("helloworld");
-        is.move_to(5, false);
-        is.insert_text("\n");
-
-        assert_eq!(is.model.text(), "hello\nworld");
-        assert_eq!(is.model.line_count(), 2);
-        assert_eq!(is.cursor_rowcol(), (1, 0));
-
-        // Continue typing on the new line
-        is.insert_text("beautiful ");
-        assert_eq!(is.model.text(), "hello\nbeautiful world");
-        assert_eq!(is.cursor_rowcol(), (1, 10));
-    }
-
-    /// Join two lines by pressing Backspace at the start of line 2.
-    #[test]
-    fn should_join_lines_with_backspace() {
-        let mut is = InputState {
-            multiline: true,
-            ..Default::default()
-        };
-
-        is.insert_text("hello\nworld");
-        assert_eq!(is.model.line_count(), 2);
-
-        // Move to start of line 2 (flat index 6 = row 1, col 0)
-        is.move_to(6, false);
-        assert_eq!(is.cursor_rowcol(), (1, 0));
-
-        // Backspace joins the lines
-        is.delete_backward();
-        assert_eq!(is.model.text(), "helloworld");
-        assert_eq!(is.model.line_count(), 1);
-        assert_eq!(is.range().active, 5);
-    }
-
-    /// Type three lines, navigate up/down, delete and re-type.
-    #[test]
-    fn should_navigate_up_delete_and_retype_line() {
-        let mut is = InputState {
-            multiline: true,
-            ..Default::default()
-        };
-
-        is.insert_text("first");
-        is.insert_text("\n");
-        is.insert_text("second");
-        is.insert_text("\n");
-        is.insert_text("third");
-        assert_eq!(is.model.text(), "first\nsecond\nthird");
-        assert_eq!(is.model.line_count(), 3);
-        assert_eq!(is.cursor_rowcol(), (2, 5));
-
-        // Move up twice to get to line 0
-        let col = is.cursor_rowcol().1;
-        is.move_up(false, Some(col));
-        assert_eq!(is.cursor_rowcol(), (1, 5));
-        is.move_up(false, Some(col));
-        assert_eq!(is.cursor_rowcol(), (0, 5));
-
-        // Delete "first" backwards (5 backspaces)
-        is.delete_backward();
-        is.delete_backward();
-        is.delete_backward();
-        is.delete_backward();
-        is.delete_backward();
-        assert_eq!(is.cursor_rowcol(), (0, 0));
-        assert_eq!(is.model.text(), "\nsecond\nthird");
-
-        // Type replacement
-        is.insert_text("ONE");
-        assert_eq!(is.model.text(), "ONE\nsecond\nthird");
-        assert_eq!(is.cursor_rowcol(), (0, 3));
-
-        // Move down to line 1 and verify we're there
-        is.move_down(false, Some(3));
-        assert_eq!(is.cursor_rowcol(), (1, 3));
-    }
-
-    /// Type text, use Home/End to navigate, then edit.
-    #[test]
-    fn should_use_home_end_to_navigate_and_edit() {
-        let mut is = InputState {
-            multiline: true,
-            ..Default::default()
-        };
-
-        is.insert_text("hello world\ngoodbye");
-        assert_eq!(is.cursor_rowcol(), (1, 7));
-
-        // Home goes to start of line 2
-        is.move_home(false);
-        assert_eq!(is.cursor_rowcol(), (1, 0));
-
-        // Insert text at beginning of line 2
-        is.insert_text("say ");
-        assert_eq!(is.model.text(), "hello world\nsay goodbye");
-        assert_eq!(is.cursor_rowcol(), (1, 4));
-
-        // Move up, then End to go to end of line 1
-        is.move_up(false, None);
-        is.move_end(false);
-        assert_eq!(is.cursor_rowcol(), (0, 11));
-
-        // Append to line 1
-        is.insert_text("!");
-        assert_eq!(is.model.text(), "hello world!\nsay goodbye");
-    }
-
-    /// Select text across lines and replace it.
-    #[test]
-    fn should_select_across_lines_and_replace() {
-        let mut is = InputState {
-            multiline: true,
-            ..Default::default()
-        };
-
-        is.insert_text("aaa\nbbb\nccc");
-        assert_eq!(is.model.line_count(), 3);
-
-        // Select from middle of line 1 to middle of line 3: "a\nbbb\nc"
-        is.set_range(SelectionRange::new(2, 9));
-        assert_eq!(is.selected_text(), "a\nbbb\nc");
-
-        // Replace selection
-        is.insert_text("X");
-        assert_eq!(is.model.text(), "aaXcc");
-        assert_eq!(is.model.line_count(), 1);
-        assert_eq!(is.range().active, 3);
+    fn blink_not_visible_unfocused() {
+        let is = InputState::new();
+        assert!(!is.blink_visible(true));
     }
 
     #[test]
-    fn should_move_down_insert_and_stuff() {
-        let mut is = InputState::default();
-        is.insert_text("Line 1\nLine 2\nLine 3");
-        is.move_to(4, false);
-        is.insert_text("A");
-        assert_eq!(is.text_content(), "LineA 1\nLine 2\nLine 3");
-        assert_eq!(is.range().active, 5);
-        is.move_down(false, None);
-        is.insert_text("B");
-        assert_eq!(is.text_content(), "LineA 1\nLine B2\nLine 3");
-        is.move_down(false, None);
-        is.insert_text("C");
-        assert_eq!(is.text_content(), "LineA 1\nLine B2\nLine 3C");
-    }
-
-    /// Simulate typing a function: type name, parens, Enter, body, Enter, close brace.
-    #[test]
-    fn should_type_function_body_and_fix_string() {
-        let mut is = InputState::default();
-
-        is.insert_text("fn main() {");
-        is.insert_text("\n");
-        is.insert_text("    println!(\"hi\");");
-        is.insert_text("\n");
-        is.insert_text("}");
-
-        assert_eq!(is.model.text(), "fn main() {\n    println!(\"hi\");\n}");
-        assert_eq!(is.model.line_count(), 3);
-        assert_eq!(is.cursor_rowcol(), (2, 1));
-
-        // Go back up to the println line and fix the message
-        is.move_up(false, Some(1));
-        assert_eq!(is.cursor_rowcol(), (1, 1));
-        is.move_end(false);
-
-        // We're at end of line 1, move left past ");" to get inside the string
-        // "    println!("hi");" — move left 3 to get after the 'i'
-        is.move_left(false); // ;
-        is.move_left(false); // )
-        is.move_left(false); // "
-        is.move_left(false); // i
-        is.move_left(false); // h
-
-        // Select "hi" (2 chars)
-        is.move_right(true);
-        is.move_right(true);
-        assert_eq!(is.selected_text(), "hi");
-
-        // Replace with "hello"
-        is.insert_text("hello");
-        assert_eq!(is.model.text(), "fn main() {\n    println!(\"hello\");\n}");
-    }
-
-    /// Move down past a shorter line, verify sticky column behavior.
-    #[test]
-    fn should_preserve_sticky_col_through_short_line() {
-        let mut is = InputState::default();
-
-        is.insert_text("long line here\nhi\nlong line here");
-        // Cursor at end: row 2, col 14
-        assert_eq!(is.cursor_rowcol(), (2, 14));
-
-        // Go to row 0, col 10
-        is.move_to(10, false);
-        assert_eq!(is.cursor_rowcol(), (0, 10));
-
-        // Move down through the short line (sticky col = 10)
-        is.move_down(false, Some(10));
-        // "hi" is only 2 chars, so we clamp to col 2
-        assert_eq!(is.cursor_rowcol(), (1, 2));
-
-        // Move down again with same sticky col
-        is.move_down(false, Some(10));
-        // Back to a long line, col 10 is available
-        assert_eq!(is.cursor_rowcol(), (2, 10));
-    }
-
-    /// Delete forward at end of line joins with next line.
-    #[test]
-    fn should_delete_forward_at_line_end_join_lines() {
-        let mut is = InputState::default();
-
-        is.insert_text("abc\ndef");
-        // Move to end of line 1 (pos 3 = row 0, col 3)
-        is.move_to(3, false);
-        assert_eq!(is.cursor_rowcol(), (0, 3));
-        is.delete_forward();
-
-        // Delete forward removes the newline
-        assert_eq!(is.model.text(), "abcdef");
-        assert_eq!(is.model.line_count(), 1);
-        assert_eq!(is.range().active, 3);
-    }
-
-    /// Type, make a mistake, backspace, correct it — common editing pattern.
-    #[test]
-    fn should_correct_typo_with_backspace() {
-        let mut is = InputState::default();
-
-        // Type "teh " (typo for "the ")
-        is.insert_text("teh ");
-        assert_eq!(is.model.text(), "teh ");
-
-        // Backspace three times to remove " ", "h", "e"
-        is.delete_backward(); // remove space → "teh"
-        is.delete_backward(); // remove h → "te"
-        is.delete_backward(); // remove e → "t"
-        assert_eq!(is.model.text(), "t");
-
-        // Re-type "he " correctly
-        is.insert_text("he ");
-        assert_eq!(is.model.text(), "the ");
-
-        // Continue typing
-        is.insert_text("quick brown fox");
-        assert_eq!(is.model.text(), "the quick brown fox");
-    }
-
-    /// Multiple Enter presses to create blank lines, then navigate and fill them.
-    #[test]
-    fn should_create_blank_lines_then_fill() {
-        let mut is = InputState::default();
-
-        is.insert_text("header");
-        is.insert_text("\n");
-        is.insert_text("\n");
-        is.insert_text("footer");
-        assert_eq!(is.model.text(), "header\n\nfooter");
-        assert_eq!(is.model.line_count(), 3);
-        assert_eq!(is.cursor_rowcol(), (2, 6));
-
-        // Navigate to the blank line (row 1)
-        is.move_up(false, Some(0));
-        is.move_up(false, Some(0));
-        assert_eq!(is.cursor_rowcol(), (0, 0));
-        is.move_down(false, Some(0));
-        assert_eq!(is.cursor_rowcol(), (1, 0));
-
-        // Type content on the blank line
-        is.insert_text("body content");
-        assert_eq!(is.model.text(), "header\nbody content\nfooter");
-        assert_eq!(is.model.line_count(), 3);
-    }
-
-    /// Word-delete backward on a multiline buffer.
-    #[test]
-    fn should_word_delete_backward_across_lines() {
-        let mut is = InputState::default();
-
-        is.insert_text("hello world\ngoodbye planet");
-        assert_eq!(is.cursor_rowcol(), (1, 14));
-
-        // Delete word backward: removes "planet"
-        is.delete_word_backward();
-        assert_eq!(is.model.text(), "hello world\ngoodbye ");
-
-        // Delete word backward: removes "goodbye"
-        is.delete_word_backward();
-        assert_eq!(is.model.text(), "hello world\n");
-
-        // One more: the newline and "world" get eaten (crosses line boundary)
-        is.delete_word_backward();
-        // Exact result depends on word boundary logic, but line count should decrease
-        assert!(is.model.line_count() <= 2);
-    }
-
-    /// Select all, delete, type fresh — common "clear and retype" workflow.
-    #[test]
-    fn should_select_all_and_retype() {
-        let mut is = InputState::default();
-
-        is.insert_text("old content\nspanning\nmultiple lines");
-        assert_eq!(is.model.line_count(), 3);
-
-        // Ctrl+A (select all) then type to replace
-        is.select_all();
-        assert_eq!(is.selected_text(), "old content\nspanning\nmultiple lines");
-
-        is.insert_text("brand new text");
-        assert_eq!(is.model.text(), "brand new text");
-        assert_eq!(is.model.line_count(), 1);
-        assert_eq!(is.range().active, 14);
-    }
-
-    // ── Clipboard helpers ───────────────────────────────────────────
-
-    #[test]
-    fn paste_replaces_selection() {
-        let mut is = input_sel("hello world", 0, 5); // "hello" selected
-        let edit = is.paste_text("goodbye");
-        assert!(edit.is_some());
-        let edit = edit.unwrap();
-        assert!(matches!(edit.kind, super::EditKind::InsertFromPaste));
-        assert_eq!(is.model.text(), "goodbye world");
-        assert_eq!(is.range().active, 7);
-    }
-
-    #[test]
-    fn paste_inserts_at_collapsed_cursor() {
-        let mut is = input_at("hello", 5);
-        let edit = is.paste_text(" world");
-        assert!(edit.is_some());
-        assert_eq!(is.model.text(), "hello world");
-        assert_eq!(is.range().active, 11);
-    }
-
-    #[test]
-    fn cut_deletes_selection_and_returns_text() {
-        let mut is = input_sel("hello world", 0, 5);
-        let result = is.cut_selected_text();
-        assert!(result.is_some());
-        let (text, edit) = result.unwrap();
-        assert_eq!(text, "hello");
-        assert!(matches!(edit.kind, super::EditKind::DeleteByCut));
-        assert_eq!(is.model.text(), " world");
-        assert!(is.range().is_collapsed());
-        assert_eq!(is.range().active, 0);
-    }
-
-    #[test]
-    fn cut_on_collapsed_selection_is_noop() {
-        let mut is = input_at("hello", 3);
-        let result = is.cut_selected_text();
-        assert!(result.is_none());
-        assert_eq!(is.model.text(), "hello");
-        assert_eq!(is.range().active, 3);
-    }
-
-    #[test]
-    fn has_selection_reports_correctly() {
-        let is = input_at("hello", 3);
-        assert!(!is.has_selection());
-
-        let is = input_sel("hello", 1, 4);
-        assert!(is.has_selection());
-    }
-
-    #[test]
-    fn secure_input_has_selection_but_clipboard_blocked_by_caller() {
-        // secure flag is checked by the caller (build_clipboard_command), not InputState
-        let mut is = input_sel("password", 0, 4);
-        is.secure = true;
-        // InputState itself doesn't block — it's the event dispatch that checks secure
-        assert!(is.has_selection());
-        assert_eq!(is.selected_text(), "pass");
-    }
-
-    #[test]
-    fn paste_on_disabled_input_is_noop() {
-        let mut is = input_at("hello", 3);
-        is.disabled = true;
-        let result = is.paste_text("world");
-        assert!(result.is_none());
-        assert_eq!(is.model.text(), "hello");
-    }
-
-    #[test]
-    fn cut_on_disabled_input_is_noop() {
-        let mut is = input_sel("hello", 0, 3);
-        is.disabled = true;
-        let result = is.cut_selected_text();
-        assert!(result.is_none());
-        assert_eq!(is.model.text(), "hello");
-    }
-
-    #[test]
-    fn paste_strips_newlines_in_single_line() {
-        let mut is = input_at("hello", 5);
-        is.multiline = false;
-        let edit = is.paste_text(" world\nfoo");
-        assert!(edit.is_some());
-        assert_eq!(is.model.text(), "hello worldfoo");
+    fn blink_not_visible_window_unfocused() {
+        let mut is = InputState::new();
+        is.focused = true;
+        assert!(!is.blink_visible(false));
     }
 }

--- a/crates/uzumaki/src/lib.rs
+++ b/crates/uzumaki/src/lib.rs
@@ -13,8 +13,6 @@ pub mod ops;
 pub mod selection;
 pub mod style;
 pub mod text;
-pub mod text_buffer;
-pub mod text_model;
 pub mod ui;
 pub mod window;
 

--- a/crates/uzumaki/src/ops/dom.rs
+++ b/crates/uzumaki/src/ops/dom.rs
@@ -162,7 +162,7 @@ pub fn op_set_input_value(
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
-            is.set_value(value);
+            is.set_value(&value);
         }
         Ok(())
     })
@@ -186,7 +186,7 @@ pub fn op_get_input_value(
             .nodes
             .get(nid)
             .and_then(|node| node.as_text_input())
-            .map(|is| is.model.text())
+            .map(|is| is.text())
             .unwrap_or_default())
     })
 }
@@ -251,7 +251,7 @@ pub fn op_set_input_max_length(
         if let Some(node) = entry.dom.nodes.get_mut(nid)
             && let Some(is) = node.as_text_input_mut()
         {
-            is.model.max_length = if max_length > 0 {
+            is.max_length = if max_length > 0 {
                 Some(max_length as usize)
             } else {
                 None

--- a/crates/uzumaki/src/text.rs
+++ b/crates/uzumaki/src/text.rs
@@ -1,14 +1,10 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use cosmic_text::fontdb;
-use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping};
+use parley::{Affinity, Cursor, FontContext, Layout, LayoutContext, LineHeight, StyleProperty};
 use unicode_segmentation::UnicodeSegmentation;
+use vello::Scene;
 use vello::kurbo::Affine;
-use vello::peniko::{Blob, Brush, Color, Fill, FontData};
-use vello::{Glyph, Scene};
+use vello::peniko::{Brush, Color, Fill};
 
-type FontId = fontdb::ID;
+type TextBrush = [u8; 4];
 
 #[derive(Clone, Copy, Debug)]
 pub struct GlyphPos2D {
@@ -17,11 +13,8 @@ pub struct GlyphPos2D {
 }
 
 pub struct TextRenderer {
-    pub font_system: FontSystem,
-    // Maps cosmic-text font IDs to vello Fonts.
-    // cosmic-text identifies loaded fonts by fontdb::ID; vello needs its own Font
-    // handle (built from the same raw bytes) to render glyph outlines on the GPU.
-    font_cache: HashMap<FontId, FontData>,
+    pub font_ctx: FontContext,
+    layout_ctx: LayoutContext<TextBrush>,
 }
 
 impl Default for TextRenderer {
@@ -32,64 +25,33 @@ impl Default for TextRenderer {
 
 impl TextRenderer {
     pub fn new() -> Self {
-        let mut font_system = FontSystem::new();
+        let mut font_ctx = FontContext::default();
 
-        // Load bundled Roboto so we always have a known font available,
-        // even on systems with limited installed fonts.
         let roboto = include_bytes!("../assets/Roboto-Regular.ttf");
-        font_system.db_mut().load_font_data(roboto.to_vec());
+        font_ctx
+            .collection
+            .register_fonts(roboto.to_vec().into(), None);
 
         Self {
-            font_system,
-            font_cache: HashMap::new(),
+            font_ctx,
+            layout_ctx: LayoutContext::new(),
         }
     }
 
-    /// Extracts raw font file bytes from cosmic-text's fontdb and constructs
-    /// a vello Font. This is the key bridge between the two libraries:
-    /// cosmic-text uses the bytes for shaping/layout (via rustybuzz),
-    /// vello uses the same bytes to read glyph outlines for GPU rendering (via skrifa).
-    fn ensure_font_cached(&mut self, font_id: FontId) {
-        if self.font_cache.contains_key(&font_id) {
-            return;
-        }
-        // fontdb::Database::with_face_data gives us the raw font file bytes
-        // and the face index within that file (relevant for .ttc collections).
-        let font_data = self
-            .font_system
-            .db()
-            .with_face_data(font_id, |data, index| (data.to_vec(), index));
-        if let Some((data, index)) = font_data {
-            let font = FontData::new(
-                Blob::new(Arc::new(data) as Arc<dyn AsRef<[u8]> + Send + Sync>),
-                index,
-            );
-            self.font_cache.insert(font_id, font);
-        }
-    }
-
-    fn layout_buffer(
+    fn build_layout(
         &mut self,
         text: &str,
-        attrs: Attrs<'_>,
         font_size: f32,
-        width: Option<f32>,
-        height: Option<f32>,
-    ) -> Buffer {
-        let metrics = Metrics::new(font_size, (font_size * 1.2).round());
-        let mut buffer = Buffer::new(&mut self.font_system, metrics);
-        buffer.set_text(&mut self.font_system, text, &attrs, Shaping::Advanced, None);
-        buffer.set_size(&mut self.font_system, width, height);
-        buffer.shape_until_scroll(&mut self.font_system, false);
-        buffer
-    }
-
-    fn cache_fonts_from_buffer(&mut self, buffer: &Buffer) {
-        for run in buffer.layout_runs() {
-            for glyph in run.glyphs.iter() {
-                self.ensure_font_cached(glyph.font_id);
-            }
-        }
+        max_width: Option<f32>,
+    ) -> Layout<TextBrush> {
+        let mut builder = self
+            .layout_ctx
+            .ranged_builder(&mut self.font_ctx, text, 1.0, true);
+        builder.push_default(StyleProperty::FontSize(font_size));
+        builder.push_default(StyleProperty::LineHeight(LineHeight::FontSizeRelative(1.2)));
+        let mut layout = builder.build(text);
+        layout.break_all_lines(max_width);
+        layout
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -97,91 +59,68 @@ impl TextRenderer {
         &mut self,
         scene: &mut Scene,
         text: &str,
-        attrs: Attrs<'_>,
         font_size: f32,
         width: f32,
-        height: f32,
+        _height: f32,
         position: (f32, f32),
         color: Color,
         scale: f64,
     ) {
-        let buffer = self.layout_buffer(text, attrs, font_size, Some(width), Some(height));
-        self.cache_fonts_from_buffer(&buffer);
-
-        // Second pass: draw glyphs, grouping consecutive runs by font_id
+        let layout = self.build_layout(text, font_size, Some(width));
         let (px, py) = position;
-        for run in buffer.layout_runs() {
-            // Group consecutive glyphs by font_id so each draw_glyphs call
-            // uses a single font (required by the vello API).
-            let mut by_font: Vec<(FontId, Vec<Glyph>)> = Vec::new();
 
-            for glyph in run.glyphs.iter() {
-                let vello_glyph = Glyph {
-                    id: glyph.glyph_id as u32,
-                    x: px + glyph.x,
-                    y: py + run.line_y,
-                };
+        for line in layout.lines() {
+            for item in line.items() {
+                if let parley::PositionedLayoutItem::GlyphRun(glyph_run) = item {
+                    let run = glyph_run.run();
+                    let font = run.font().clone();
+                    let run_font_size = run.font_size();
+                    let synthesis = run.synthesis();
+                    let glyph_xform = synthesis
+                        .skew()
+                        .map(|angle| Affine::skew(angle.to_radians().tan() as f64, 0.0));
 
-                if let Some(last) = by_font.last_mut()
-                    && last.0 == glyph.font_id
-                {
-                    last.1.push(vello_glyph);
-                    continue;
-                }
-                by_font.push((glyph.font_id, vec![vello_glyph]));
-            }
-
-            for (font_id, glyphs) in by_font {
-                if let Some(vello_font) = self.font_cache.get(&font_id) {
                     scene
-                        .draw_glyphs(vello_font)
-                        .font_size(font_size)
+                        .draw_glyphs(&font)
+                        .font_size(run_font_size)
                         .transform(Affine::scale(scale))
+                        .glyph_transform(glyph_xform)
                         .brush(&Brush::Solid(color))
-                        .draw(Fill::NonZero, glyphs.into_iter());
+                        .draw(
+                            Fill::NonZero,
+                            glyph_run.positioned_glyphs().map(|g| vello::Glyph {
+                                id: g.id as u32,
+                                x: px + g.x,
+                                y: py + g.y,
+                            }),
+                        );
                 }
             }
         }
     }
 
-    /// Returns x-positions for each grapheme boundary in the text.
-    /// Result has `grapheme_count + 1` entries: [0] = 0.0, [n] = end of text.
     pub fn grapheme_x_positions(&mut self, text: &str, font_size: f32) -> Vec<f32> {
         if text.is_empty() {
             return vec![0.0];
         }
 
-        let buffer = self.layout_buffer(text, Attrs::new(), font_size, None, None);
+        let layout = self.build_layout(text, font_size, None);
+        let layout_width = layout.width();
 
-        // Build byte offset → x position mapping from glyphs
-        let mut byte_x: Vec<(usize, f32)> = Vec::new();
-        byte_x.push((0, 0.0));
-
-        for run in buffer.layout_runs() {
-            for glyph in run.glyphs.iter() {
-                byte_x.push((glyph.start, glyph.x));
-                byte_x.push((glyph.end, glyph.x + glyph.w));
-            }
-        }
-
-        byte_x.sort_by_key(|&(offset, _)| offset);
-        byte_x.dedup_by_key(|entry| entry.0);
-
-        // Map grapheme boundaries to x positions
         let mut positions = Vec::new();
-        positions.push(lookup_byte_x(&byte_x, 0));
+        positions.push(0.0);
 
         let mut byte_offset = 0;
         for grapheme in text.graphemes(true) {
             byte_offset += grapheme.len();
-            positions.push(lookup_byte_x(&byte_x, byte_offset));
+            let cursor = Cursor::from_byte_index(&layout, byte_offset, Affinity::Downstream);
+            let geom = cursor.geometry(&layout, layout_width);
+            positions.push(geom.x0 as f32);
         }
 
         positions
     }
 
-    /// Hit-test an x-coordinate against text layout, returning the grapheme index
-    /// (cursor position) closest to that x.
     pub fn hit_to_grapheme(&mut self, text: &str, font_size: f32, x: f32) -> usize {
         let positions = self.grapheme_x_positions(text, font_size);
         let mut best_idx = 0;
@@ -196,9 +135,6 @@ impl TextRenderer {
         best_idx
     }
 
-    /// Returns (x, y) positions for each grapheme boundary in multiline text.
-    /// `wrap_width` controls line wrapping. Result has `grapheme_count + 1` entries.
-    /// y values are line-top relative to buffer origin.
     pub fn grapheme_positions_2d(
         &mut self,
         text: &str,
@@ -209,92 +145,46 @@ impl TextRenderer {
             return vec![GlyphPos2D { x: 0.0, y: 0.0 }];
         }
 
-        let buffer = self.layout_buffer(text, Attrs::new(), font_size, wrap_width, None);
-
-        let mut byte_pos: Vec<(usize, f32, f32)> = Vec::new();
-
-        // Compute byte offset of each line start for mapping empty runs
-        let mut line_starts: Vec<usize> = vec![0];
-        for (i, ch) in text.char_indices() {
-            if ch == '\n' {
-                line_starts.push(i + 1);
-            }
-        }
-
+        let layout = self.build_layout(text, font_size, wrap_width);
+        let layout_width = layout.width().max(wrap_width.unwrap_or(f32::MAX));
         let line_height = (font_size * 1.2).round();
-        let mut first_line_top: Option<f32> = None;
-        let mut last_line_top: f32 = 0.0;
 
-        for run in buffer.layout_runs() {
-            let line_top = run.line_top;
-            if first_line_top.is_none() {
-                first_line_top = Some(line_top);
-            }
-            if line_top >= last_line_top {
-                last_line_top = line_top;
-            }
+        let first_line_y = layout
+            .lines()
+            .next()
+            .map(|l| (l.metrics().baseline - l.metrics().ascent) as f32)
+            .unwrap_or(0.0);
 
-            // cosmic-text glyph byte offsets are relative to the line (paragraph),
-            // not the full text. Convert to absolute text byte offsets.
-            let line_byte_offset = line_starts.get(run.line_i).copied().unwrap_or(0);
-
-            if run.glyphs.is_empty() {
-                byte_pos.push((line_byte_offset, 0.0, line_top));
-            } else {
-                for glyph in run.glyphs.iter() {
-                    byte_pos.push((line_byte_offset + glyph.start, glyph.x, line_top));
-                    byte_pos.push((line_byte_offset + glyph.end, glyph.x + glyph.w, line_top));
-                }
-            }
-        }
-
-        let first_y = first_line_top.unwrap_or(0.0);
-
-        if !byte_pos.iter().any(|&(off, _, _)| off == 0) {
-            byte_pos.push((0, 0.0, first_y));
-        }
-
-        if text.ends_with('\n') {
-            let end_byte = text.len();
-            if !byte_pos.iter().any(|&(off, _, _)| off == end_byte) {
-                byte_pos.push((end_byte, 0.0, last_line_top + line_height));
-            }
-        }
-
-        if !byte_pos.iter().any(|&(off, _, _)| off == text.len()) {
-            let last = byte_pos
-                .last()
-                .map(|&(_, x, y)| (x, y))
-                .unwrap_or((0.0, first_y));
-            byte_pos.push((text.len(), last.0, last.1));
-        }
-
-        byte_pos.sort_by(|a, b| {
-            a.0.cmp(&b.0)
-                .then(a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
-        });
-
-        // Map grapheme boundaries to (x, y), normalizing y to zero-based.
-        // Always prefer next line at line breaks: at hard newlines (\n) this
-        // picks the start of the next line; at soft-wrap boundaries this picks
-        // (x=0, next_visual_line_y) instead of (end_x, current_line_y).
-        // At non-break positions there is only one entry so the flag is a no-op.
         let mut positions = Vec::new();
         positions.push(GlyphPos2D { x: 0.0, y: 0.0 });
 
         let mut byte_offset = 0;
         for grapheme in text.graphemes(true) {
             byte_offset += grapheme.len();
-            let mut pos = lookup_byte_pos_2d(&byte_pos, byte_offset, true);
-            pos.y -= first_y;
-            positions.push(pos);
+            let cursor = Cursor::from_byte_index(&layout, byte_offset, Affinity::Downstream);
+            let geom = cursor.geometry(&layout, layout_width);
+            let x = geom.x0 as f32;
+            let y = geom.y0 as f32 - first_line_y;
+            positions.push(GlyphPos2D { x, y });
         }
 
-        // Normalize the first position too (it was set to 0.0 above, which is correct)
+        // Handle trailing newline: cursor should be on a new line at x=0
+        if text.ends_with('\n') {
+            let len = positions.len();
+            let last = &positions[len - 1];
+            let needs_fix =
+                last.x.abs() > 1.0 || (len > 2 && (last.y - positions[len - 2].y).abs() < 1.0);
+            if needs_fix {
+                let prev_y = if len > 2 { positions[len - 2].y } else { 0.0 };
+                let last = positions.last_mut().unwrap();
+                last.x = 0.0;
+                last.y = prev_y + line_height;
+            }
+        }
+
         positions
     }
 
-    /// Hit-test an (x, y) coordinate against multiline text layout.
     pub fn hit_to_grapheme_2d(
         &mut self,
         text: &str,
@@ -304,9 +194,8 @@ impl TextRenderer {
         y: f32,
     ) -> usize {
         let positions = self.grapheme_positions_2d(text, font_size, wrap_width);
-        let line_height = (font_size * 1.2).round(); // match cosmic-text Metrics
+        let line_height = (font_size * 1.2).round();
 
-        // Collect unique line y values
         let mut line_ys: Vec<f32> = Vec::new();
         for pos in &positions {
             if line_ys
@@ -317,8 +206,6 @@ impl TextRenderer {
             }
         }
 
-        // Find which line the y coordinate falls on.
-        // Use the line whose vertical range [ly, ly + line_height) contains y.
         let mut target_y = line_ys.first().copied().unwrap_or(0.0);
         for &ly in &line_ys {
             if y >= ly {
@@ -326,7 +213,6 @@ impl TextRenderer {
             }
         }
 
-        // Among positions on that line, find closest x
         let mut best_idx = 0;
         let mut best_dist = f32::MAX;
         for (i, pos) in positions.iter().enumerate() {
@@ -344,104 +230,29 @@ impl TextRenderer {
     pub fn measure_text(
         &mut self,
         text: &str,
-        attrs: Attrs<'_>,
         font_size: f32,
         max_width: Option<f32>,
-        max_height: Option<f32>,
+        _max_height: Option<f32>,
     ) -> (f32, f32) {
-        let buffer = self.layout_buffer(text, attrs, font_size, max_width, max_height);
-        self.cache_fonts_from_buffer(&buffer);
+        let layout = self.build_layout(text, font_size, max_width);
 
-        let mut measured_width: f32 = 0.0;
-        let mut measured_height: f32 = 0.0;
+        let measured_width = layout.width();
+        let measured_height = layout.height();
+        let line_height = (font_size * 1.2).round();
 
-        for run in buffer.layout_runs() {
-            // Use glyph extents to avoid relying on line_w when wrap width is tiny.
-            for glyph in run.glyphs.iter() {
-                measured_width = measured_width.max(glyph.x + glyph.w);
-            }
-            measured_height = measured_height.max(run.line_top + run.line_height);
-        }
-
-        if measured_height == 0.0 {
-            measured_height = buffer.metrics().line_height;
-        }
-        if measured_width == 0.0 {
-            measured_width = (text.len() as f32) * (font_size * 0.6);
-        }
-
-        (measured_width.ceil(), measured_height.ceil())
-    }
-}
-
-/// Look up a byte offset in the (sorted, non-deduped) position list.
-/// `prefer_next_line`: when true (after \n), pick the entry with highest y at this offset;
-/// when false (soft-wrap), pick the entry with lowest y (end of current line).
-fn lookup_byte_pos_2d(
-    byte_pos: &[(usize, f32, f32)],
-    byte_offset: usize,
-    prefer_next_line: bool,
-) -> GlyphPos2D {
-    // Find range of entries matching this byte offset (array is sorted by offset then y).
-    let start = byte_pos.partition_point(|&(off, _, _)| off < byte_offset);
-    let end = byte_pos.partition_point(|&(off, _, _)| off <= byte_offset);
-
-    if start < end {
-        // One or more entries match. Since sorted by y ascending:
-        // - lowest y (current line end) is at `start`
-        // - highest y (next line start) is at `end - 1`
-        let idx = if prefer_next_line { end - 1 } else { start };
-        return GlyphPos2D {
-            x: byte_pos[idx].1,
-            y: byte_pos[idx].2,
-        };
-    }
-
-    // No exact match — interpolate between neighbors
-    if start == 0 {
-        GlyphPos2D { x: 0.0, y: 0.0 }
-    } else if start >= byte_pos.len() {
-        byte_pos
-            .last()
-            .map(|&(_, x, y)| GlyphPos2D { x, y })
-            .unwrap_or(GlyphPos2D { x: 0.0, y: 0.0 })
-    } else {
-        let (off0, x0, y0) = byte_pos[start - 1];
-        let (off1, x1, y1) = byte_pos[start];
-        if (y0 - y1).abs() > 1.0 {
-            // Cross-line: snap to nearest entry
-            let d0 = byte_offset - off0;
-            let d1 = off1 - byte_offset;
-            if d0 <= d1 {
-                GlyphPos2D { x: x0, y: y0 }
-            } else {
-                GlyphPos2D { x: x1, y: y1 }
-            }
+        let w = if measured_width == 0.0 {
+            (text.len() as f32) * (font_size * 0.6)
         } else {
-            let t = (byte_offset - off0) as f32 / (off1 - off0).max(1) as f32;
-            GlyphPos2D {
-                x: x0 + t * (x1 - x0),
-                y: y0,
-            }
-        }
-    }
-}
+            measured_width
+        };
 
-fn lookup_byte_x(byte_x: &[(usize, f32)], byte_offset: usize) -> f32 {
-    match byte_x.binary_search_by_key(&byte_offset, |&(off, _)| off) {
-        Ok(idx) => byte_x[idx].1,
-        Err(idx) => {
-            if idx == 0 {
-                0.0
-            } else if idx >= byte_x.len() {
-                byte_x.last().map(|&(_, x)| x).unwrap_or(0.0)
-            } else {
-                let (off0, x0) = byte_x[idx - 1];
-                let (off1, x1) = byte_x[idx];
-                let t = (byte_offset - off0) as f32 / (off1 - off0).max(1) as f32;
-                x0 + t * (x1 - x0)
-            }
-        }
+        let h = if measured_height == 0.0 {
+            line_height
+        } else {
+            measured_height
+        };
+
+        (w.ceil(), h.ceil())
     }
 }
 
@@ -454,59 +265,6 @@ mod tests {
     fn renderer() -> TextRenderer {
         TextRenderer::new()
     }
-
-    // ── lookup_byte_pos_2d (pure function) ──────────────────────────
-
-    #[test]
-    fn lookup_single_entry() {
-        let byte_pos = vec![(0, 0.0f32, 0.0f32), (5, 50.0, 0.0)];
-        let pos = lookup_byte_pos_2d(&byte_pos, 0, true);
-        assert!((pos.x - 0.0).abs() < 0.01);
-        assert!((pos.y - 0.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn lookup_prefers_next_line_at_wrap() {
-        // Simulates a soft-wrap boundary at byte 3:
-        // end-of-line-0 at (3, 30.0, 0.0) and start-of-line-1 at (3, 0.0, 20.0)
-        let byte_pos = vec![
-            (0, 0.0f32, 0.0f32),
-            (3, 30.0, 0.0),
-            (3, 0.0, 20.0),
-            (6, 30.0, 20.0),
-        ];
-
-        let next = lookup_byte_pos_2d(&byte_pos, 3, true);
-        assert!(
-            (next.x - 0.0).abs() < 0.01,
-            "prefer_next_line should pick x=0"
-        );
-        assert!(
-            (next.y - 20.0).abs() < 0.01,
-            "prefer_next_line should pick y=20"
-        );
-
-        let curr = lookup_byte_pos_2d(&byte_pos, 3, false);
-        assert!(
-            (curr.x - 30.0).abs() < 0.01,
-            "prefer_current should pick x=30"
-        );
-        assert!(
-            (curr.y - 0.0).abs() < 0.01,
-            "prefer_current should pick y=0"
-        );
-    }
-
-    #[test]
-    fn lookup_interpolates_between_neighbors() {
-        // Byte offsets 0 and 4 at x=0 and x=40 on same line
-        let byte_pos = vec![(0, 0.0f32, 0.0f32), (4, 40.0, 0.0)];
-        let pos = lookup_byte_pos_2d(&byte_pos, 2, false);
-        assert!((pos.x - 20.0).abs() < 0.01, "should interpolate to x=20");
-        assert!((pos.y - 0.0).abs() < 0.01);
-    }
-
-    // ── grapheme_positions_2d ───────────────────────────────────────
 
     #[test]
     fn positions_2d_single_line_count() {
@@ -546,15 +304,12 @@ mod tests {
     fn positions_2d_hard_newline_two_lines() {
         let mut r = renderer();
         let pos = r.grapheme_positions_2d("ab\ncd", 16.0, None);
-        // 5 graphemes (a, b, \n, c, d) + 1 = 6
         assert_eq!(pos.len(), 6);
 
-        // First 3 positions (before-a, after-a, after-b) on line 0
         assert!(pos[0].y.abs() < 1.0);
         assert!(pos[1].y.abs() < 1.0);
         assert!(pos[2].y.abs() < 1.0);
 
-        // After \n → start of line 1
         let line1_y = pos[3].y;
         assert!(line1_y > 1.0, "line 1 y should be > 0, got {}", line1_y);
         assert!(
@@ -563,7 +318,6 @@ mod tests {
             pos[3].x
         );
 
-        // Remaining on line 1
         assert!((pos[4].y - line1_y).abs() < 1.0);
         assert!((pos[5].y - line1_y).abs() < 1.0);
     }
@@ -572,9 +326,7 @@ mod tests {
     fn positions_2d_x_resets_on_new_line() {
         let mut r = renderer();
         let pos = r.grapheme_positions_2d("abc\nde", 16.0, None);
-        // After \n = pos[4], should be at x≈0 on line 1
         assert!(pos[4].x < 1.0, "first char on line 1 should be near x=0");
-        // After first char on line 1, x should increase
         assert!(
             pos[5].x > pos[4].x,
             "x should increase on line 1: {} > {}",
@@ -587,11 +339,8 @@ mod tests {
     fn positions_2d_empty_line_between() {
         let mut r = renderer();
         let pos = r.grapheme_positions_2d("a\n\nb", 16.0, None);
-        // Graphemes: a, \n, \n, b → 4 graphemes + 1 = 5 positions
         assert_eq!(pos.len(), 5);
 
-        // pos[2] = after first \n = start of empty line
-        // pos[3] = after second \n = start of line with "b"
         assert!(
             pos[3].y > pos[2].y,
             "line after empty should be below: {} > {}",
@@ -605,7 +354,6 @@ mod tests {
     fn positions_2d_trailing_newline() {
         let mut r = renderer();
         let pos = r.grapheme_positions_2d("abc\n", 16.0, None);
-        // Graphemes: a, b, c, \n → 4 graphemes + 1 = 5 positions
         assert_eq!(pos.len(), 5);
         let last = pos.last().unwrap();
         assert!(
@@ -622,11 +370,8 @@ mod tests {
     #[test]
     fn positions_2d_wrapping_creates_multiple_visual_lines() {
         let mut r = renderer();
-        // Use very narrow width to force wrapping. At font_size 16, each char is ~9px.
-        // "abcdef ghij" with wrap_width=50 should wrap.
         let pos = r.grapheme_positions_2d("abcdef ghij", 16.0, Some(50.0));
 
-        // Collect unique y values
         let mut ys: Vec<f32> = vec![pos[0].y];
         for p in &pos[1..] {
             if ys.last().is_none_or(|&ly| (p.y - ly).abs() > 1.0) {
@@ -643,10 +388,8 @@ mod tests {
     #[test]
     fn positions_2d_wrap_break_at_start_of_next_line() {
         let mut r = renderer();
-        // Force a wrap. With very narrow width, even "ab cd" wraps.
         let pos = r.grapheme_positions_2d("ab cd", 16.0, Some(30.0));
 
-        // Find the first position on a second visual line
         let line0_y = pos[0].y;
         let first_on_line1 = pos.iter().find(|p| (p.y - line0_y).abs() > 1.0);
         if let Some(p) = first_on_line1 {
@@ -667,7 +410,6 @@ mod tests {
         let mut prev_x = -1.0f32;
         for p in &pos {
             if (p.y - current_y).abs() > 1.0 {
-                // New line — reset x tracking
                 current_y = p.y;
                 prev_x = -1.0;
             }
@@ -685,18 +427,15 @@ mod tests {
     fn positions_2d_three_lines() {
         let mut r = renderer();
         let pos = r.grapheme_positions_2d("aaa\nbbb\nccc", 16.0, None);
-        // 11 graphemes + 1 = 12
         assert_eq!(pos.len(), 12);
 
-        // Three distinct y values
         let y0 = pos[0].y;
-        let y1 = pos[4].y; // after first \n
-        let y2 = pos[8].y; // after second \n
+        let y1 = pos[4].y;
+        let y2 = pos[8].y;
 
         assert!(y1 > y0 + 1.0, "line 1 below line 0");
         assert!(y2 > y1 + 1.0, "line 2 below line 1");
 
-        // Lines are evenly spaced
         let spacing_01 = y1 - y0;
         let spacing_12 = y2 - y1;
         assert!(
@@ -706,8 +445,6 @@ mod tests {
             spacing_12
         );
     }
-
-    // ── hit_to_grapheme_2d ──────────────────────────────────────────
 
     #[test]
     fn hit_2d_start_of_text() {
@@ -720,9 +457,8 @@ mod tests {
     fn hit_2d_second_line() {
         let mut r = renderer();
         let pos = r.grapheme_positions_2d("abc\ndef", 16.0, None);
-        let line1_y = pos[4].y; // start of "def" line
+        let line1_y = pos[4].y;
 
-        // Click at x=0 on line 1 → should be at start of line 1
         let idx = r.hit_to_grapheme_2d("abc\ndef", 16.0, None, 0.0, line1_y + 2.0);
         assert_eq!(
             idx, 4,
@@ -739,8 +475,6 @@ mod tests {
         let idx = r.hit_to_grapheme_2d("abc", 16.0, None, last_x + 100.0, 0.0);
         assert_eq!(idx, 3, "clicking past end should give last position");
     }
-
-    // ── grapheme_x_positions (singleline) ───────────────────────────
 
     #[test]
     fn x_positions_count() {

--- a/crates/uzumaki/src/text.rs
+++ b/crates/uzumaki/src/text.rs
@@ -90,7 +90,7 @@ impl TextRenderer {
                         .draw(
                             Fill::NonZero,
                             glyph_run.positioned_glyphs().map(|g| vello::Glyph {
-                                id: g.id as u32,
+                                id: g.id,
                                 x: px + g.x,
                                 y: py + g.y,
                             }),
@@ -153,7 +153,7 @@ impl TextRenderer {
         let first_line_y = layout
             .lines()
             .next()
-            .map(|l| (l.metrics().baseline - l.metrics().ascent) as f32)
+            .map(|l| l.metrics().baseline - l.metrics().ascent)
             .unwrap_or(0.0);
 
         let mut positions = Vec::new();

--- a/crates/uzumaki/src/text.rs
+++ b/crates/uzumaki/src/text.rs
@@ -4,7 +4,8 @@ use vello::Scene;
 use vello::kurbo::Affine;
 use vello::peniko::{Brush, Color, Fill};
 
-type TextBrush = [u8; 4];
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct TextBrush;
 
 #[derive(Clone, Copy, Debug)]
 pub struct GlyphPos2D {
@@ -14,7 +15,7 @@ pub struct GlyphPos2D {
 
 pub struct TextRenderer {
     pub font_ctx: FontContext,
-    layout_ctx: LayoutContext<TextBrush>,
+    pub layout_ctx: LayoutContext<TextBrush>,
 }
 
 impl Default for TextRenderer {
@@ -255,8 +256,6 @@ impl TextRenderer {
         (w.ceil(), h.ceil())
     }
 }
-
-// ── Tests ────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Migrates the entire text stack from cosmic-text to parley 0.8.
Parley's FontContext, LayoutContext, and Cursor APIs now handle
all text layout, glyph rendering, measurement, and hit-testing.
Removes the manual fontdb-to-vello font cache bridge.## Description

<!-- What does this PR do and why? -->

## Checklist

- [x] I have run `cargo fmt` and `pnpm format`
- [x] I have run `cargo clippy --workspace -D warnings` and `pnpm lint` with no errors
- [x] I have manually tested my changes
- [x] This PR is focused on a single scope — no unrelated drive-by changes
- [x] If this PR uses AI-generated code, I have thoroughly reviewed and tested every line myself
