### PR TITLE
feat: focus next

### DIFF
--- a/crates/uzumaki/js/react/jsx/types.ts
+++ b/crates/uzumaki/js/react/jsx/types.ts
@@ -50,6 +50,9 @@ interface ElementStyles {
   borderBottom?: number | string;
   borderLeft?: number | string;
   borderColor?: string;
+  outline?: number | string;
+  outlineColor?: string;
+  outlineOffset?: number | string;
   opacity?: number | string;
   cursor?:
     | 'default'

--- a/crates/uzumaki/src/app.rs
+++ b/crates/uzumaki/src/app.rs
@@ -769,7 +769,12 @@ impl ApplicationHandler<UserEvent> for Application {
                         let tab_outcome = {
                             let mut state = self.app_state.borrow_mut();
                             state.windows.get_mut(&wid).map(|entry| {
-                                event_dispatch::handle_tab_focus(&mut entry.dom, wid, &key_event)
+                                event_dispatch::handle_tab_focus(
+                                    &mut entry.dom,
+                                    wid,
+                                    &key_event,
+                                    modifiers,
+                                )
                             })
                         };
                         let tab_consumed = if let Some(outcome) = tab_outcome {
@@ -875,14 +880,24 @@ impl ApplicationHandler<UserEvent> for Application {
                                             wid,
                                             &key_event,
                                         );
+                                    let (button_redraw, button_events) =
+                                        event_dispatch::handle_key_for_button(
+                                            &mut entry.dom,
+                                            wid,
+                                            &key_event,
+                                        );
                                     if redraw {
                                         needs_redraw = true;
                                     }
                                     if checkbox_redraw {
                                         needs_redraw = true;
                                     }
+                                    if button_redraw {
+                                        needs_redraw = true;
+                                    }
                                     let mut all_events = events;
                                     all_events.extend(checkbox_events);
+                                    all_events.extend(button_events);
                                     all_events
                                 })
                             };

--- a/crates/uzumaki/src/app.rs
+++ b/crates/uzumaki/src/app.rs
@@ -765,7 +765,26 @@ impl ApplicationHandler<UserEvent> for Application {
                     if let Some(event_dispatch::AppEvent::HotReload) = raw_event {
                         // todo hotreload :3
                     } else {
-                        // 2a. Check for clipboard shortcuts (Ctrl+C/X/V)
+                        // 2a. Tab: switch focus to next focusable element
+                        let tab_outcome = {
+                            let mut state = self.app_state.borrow_mut();
+                            state.windows.get_mut(&wid).map(|entry| {
+                                event_dispatch::handle_tab_focus(&mut entry.dom, wid, &key_event)
+                            })
+                        };
+                        let tab_consumed = if let Some(outcome) = tab_outcome {
+                            if outcome.needs_redraw {
+                                needs_redraw = true;
+                            }
+                            for event in &outcome.events {
+                                self.dispatch_event_to_js(event);
+                            }
+                            outcome.consumed
+                        } else {
+                            false
+                        };
+
+                        // 2b. Check for clipboard shortcuts (Ctrl+C/X/V)
                         let clipboard_cmd = {
                             let state = self.app_state.borrow();
 
@@ -777,7 +796,9 @@ impl ApplicationHandler<UserEvent> for Application {
                             })
                         };
 
-                        let clipboard_consumed = if let Some(cmd) = clipboard_cmd {
+                        let clipboard_consumed = if tab_consumed {
+                            true
+                        } else if let Some(cmd) = clipboard_cmd {
                             // Dispatch clipboard event to JS
                             let clipboard_event =
                                 event_dispatch::clipboard_command_to_event(&cmd, wid);

--- a/crates/uzumaki/src/element.rs
+++ b/crates/uzumaki/src/element.rs
@@ -568,4 +568,12 @@ impl Node {
     pub fn default_cursor(&self) -> Option<UzCursorIcon> {
         self.data.default_cursor()
     }
+
+    /// Whether this node can receive keyboard focus. Driven by the element's
+    /// `is_focussable` flag so views can opt in (e.g. buttons, contenteditable).
+    pub fn is_focusable(&self) -> bool {
+        self.as_element()
+            .map(|e| e.is_focussable())
+            .unwrap_or(false)
+    }
 }

--- a/crates/uzumaki/src/element.rs
+++ b/crates/uzumaki/src/element.rs
@@ -569,8 +569,7 @@ impl Node {
         self.data.default_cursor()
     }
 
-    /// Whether this node can receive keyboard focus. Driven by the element's
-    /// `is_focussable` flag so views can opt in (e.g. buttons, contenteditable).
+    /// Whether this node can receive keyboard focus.
     pub fn is_focusable(&self) -> bool {
         self.as_element()
             .map(|e| e.is_focussable())

--- a/crates/uzumaki/src/element/input.rs
+++ b/crates/uzumaki/src/element/input.rs
@@ -52,18 +52,12 @@ pub fn paint_input(
     let content_w = (bounds.width - pad_l - pad_r).max(0.0);
     let content_h = (bounds.height - pad_t - pad_b).max(0.0);
 
-    // Paint background with focus-aware border
     let mut paint_style = style.clone();
-    if input.focused {
-        paint_style.border_widths = Edges::all(2.0);
-        paint_style.border_color = Some(Color::rgba(86, 156, 214, 255));
-    } else {
-        if !paint_style.border_widths.any_nonzero() {
-            paint_style.border_widths = Edges::all(1.0);
-        }
-        if paint_style.border_color.is_none() {
-            paint_style.border_color = Some(Color::rgba(60, 60, 60, 255));
-        }
+    if !paint_style.border_widths.any_nonzero() {
+        paint_style.border_widths = Edges::all(1.0);
+    }
+    if paint_style.border_color.is_none() {
+        paint_style.border_color = Some(Color::rgba(60, 60, 60, 255));
     }
     if paint_style.background.is_none() {
         paint_style.background = Some(Color::rgba(30, 30, 30, 255));

--- a/crates/uzumaki/src/element/selection.rs
+++ b/crates/uzumaki/src/element/selection.rs
@@ -176,4 +176,82 @@ impl UIState {
     pub fn clear_selection(&mut self) {
         self.text_selection.clear();
     }
+
+    /// Walk the DOM in document order from `start_id`, returning the next node
+    /// for which `filter` returns true. Wraps to the root once and stops if the
+    /// traversal returns to `start_id` without a match.
+    pub fn next_node(
+        &self,
+        start_id: UzNodeId,
+        mut filter: impl FnMut(&super::Node) -> bool,
+    ) -> Option<UzNodeId> {
+        let mut node_id = start_id;
+        let mut look_in_children = true;
+        loop {
+            let cur = self.nodes.get(node_id)?;
+            let next_id = if look_in_children && let Some(first) = cur.first_child {
+                first
+            } else if let Some(parent_id) = cur.parent {
+                if let Some(sibling) = cur.next_sibling {
+                    look_in_children = true;
+                    sibling
+                } else {
+                    look_in_children = false;
+                    node_id = parent_id;
+                    continue;
+                }
+            } else {
+                look_in_children = true;
+                self.root?
+            };
+
+            let next = self.nodes.get(next_id)?;
+            if filter(next) {
+                return Some(next_id);
+            }
+            if next_id == start_id {
+                return None;
+            }
+            node_id = next_id;
+        }
+    }
+
+    /// Move focus to the next focusable element (text input or checkbox) in
+    /// document order. Returns the previous and new focus ids when focus
+    /// actually changed, allowing callers to dispatch blur/focus events.
+    pub fn focus_next_node(&mut self) -> Option<FocusChange> {
+        let start_id = self.focused_node.or(self.root)?;
+        let new_id = self.next_node(start_id, |n| n.is_focusable())?;
+
+        let old = self.focused_node;
+        if old == Some(new_id) {
+            return None;
+        }
+        if let Some(old_id) = old
+            && let Some(node) = self.nodes.get_mut(old_id)
+            && let Some(is) = node.as_text_input_mut()
+        {
+            is.focused = false;
+        }
+
+        let is_input = self
+            .nodes
+            .get(new_id)
+            .map(|n| n.is_text_input())
+            .unwrap_or(false);
+        if is_input {
+            self.focus_input(new_id);
+        } else {
+            self.clear_selection();
+            self.focused_node = Some(new_id);
+        }
+
+        Some(FocusChange { old, new: new_id })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FocusChange {
+    pub old: Option<UzNodeId>,
+    pub new: UzNodeId,
 }

--- a/crates/uzumaki/src/element/selection.rs
+++ b/crates/uzumaki/src/element/selection.rs
@@ -216,12 +216,60 @@ impl UIState {
         }
     }
 
-    /// Move focus to the next focusable element (text input or checkbox) in
-    /// document order. Returns the previous and new focus ids when focus
-    /// actually changed, allowing callers to dispatch blur/focus events.
+    /// Walk the DOM in reverse document order. At each step go to the previous
+    /// sibling's deepest-last descendant, or up to the parent. Wraps to the
+    /// deepest-last descendant of root.
+    pub fn prev_node(
+        &self,
+        start_id: UzNodeId,
+        mut filter: impl FnMut(&super::Node) -> bool,
+    ) -> Option<UzNodeId> {
+        let mut node_id = start_id;
+        loop {
+            let cur = self.nodes.get(node_id)?;
+            let next_id = if let Some(prev) = cur.prev_sibling {
+                self.deepest_last(prev)
+            } else if let Some(parent) = cur.parent {
+                parent
+            } else {
+                self.deepest_last(self.root?)
+            };
+
+            let next = self.nodes.get(next_id)?;
+            if filter(next) {
+                return Some(next_id);
+            }
+            if next_id == start_id {
+                return None;
+            }
+            node_id = next_id;
+        }
+    }
+
+    fn deepest_last(&self, mut id: UzNodeId) -> UzNodeId {
+        while let Some(last) = self.nodes.get(id).and_then(|n| n.last_child) {
+            id = last;
+        }
+        id
+    }
+
+    /// Move focus to the next focusable element in document order.
     pub fn focus_next_node(&mut self) -> Option<FocusChange> {
+        self.focus_step(false)
+    }
+
+    /// Move focus to the previous focusable element in document order.
+    pub fn focus_prev_node(&mut self) -> Option<FocusChange> {
+        self.focus_step(true)
+    }
+
+    fn focus_step(&mut self, backward: bool) -> Option<FocusChange> {
         let start_id = self.focused_node.or(self.root)?;
-        let new_id = self.next_node(start_id, |n| n.is_focusable())?;
+        let new_id = if backward {
+            self.prev_node(start_id, |n| n.is_focusable())?
+        } else {
+            self.next_node(start_id, |n| n.is_focusable())?
+        };
 
         let old = self.focused_node;
         if old == Some(new_id) {

--- a/crates/uzumaki/src/event_dispatch.rs
+++ b/crates/uzumaki/src/event_dispatch.rs
@@ -1094,6 +1094,52 @@ pub fn handle_key_for_checkbox(
     )
 }
 
+pub struct TabFocusOutcome {
+    pub consumed: bool,
+    pub needs_redraw: bool,
+    pub events: Vec<AppEvent>,
+}
+
+/// Handle Tab to advance focus to the next focusable element. Tab is always
+/// consumed (never inserts a tab character into a focused input).
+pub fn handle_tab_focus(
+    dom: &mut UIState,
+    wid: u32,
+    key_event: &winit::event::KeyEvent,
+) -> TabFocusOutcome {
+    use winit::event::ElementState;
+
+    let mut outcome = TabFocusOutcome {
+        consumed: false,
+        needs_redraw: false,
+        events: Vec::new(),
+    };
+
+    if key_event.state != ElementState::Pressed
+        || !matches!(&key_event.logical_key, Key::Named(NamedKey::Tab))
+    {
+        return outcome;
+    }
+
+    outcome.consumed = true;
+
+    if let Some(change) = dom.focus_next_node() {
+        if let Some(old) = change.old {
+            outcome.events.push(AppEvent::Blur(FocusEventData {
+                window_id: wid,
+                node_id: old,
+            }));
+        }
+        outcome.events.push(AppEvent::Focus(FocusEventData {
+            window_id: wid,
+            node_id: change.new,
+        }));
+        outcome.needs_redraw = true;
+    }
+
+    outcome
+}
+
 /// Handle keyboard shortcuts for view text selection (Shift+Arrows, Ctrl+A, etc.)
 /// Called after input-level processing, only when there's no focused input.
 /// Returns true if a redraw is needed.

--- a/crates/uzumaki/src/event_dispatch.rs
+++ b/crates/uzumaki/src/event_dispatch.rs
@@ -1094,18 +1094,81 @@ pub fn handle_key_for_checkbox(
     )
 }
 
+/// Handle Enter/Space on a focused button-like element (focusable view that's
+/// not a text input or checkbox). Fires a synthetic click, mirroring browser
+/// behavior on `<button>`.
+pub fn handle_key_for_button(
+    dom: &mut UIState,
+    wid: u32,
+    key_event: &winit::event::KeyEvent,
+) -> (bool, Vec<AppEvent>) {
+    use winit::event::ElementState;
+
+    if key_event.state != ElementState::Pressed {
+        return (false, Vec::new());
+    }
+    if !matches!(
+        &key_event.logical_key,
+        Key::Named(NamedKey::Enter) | Key::Named(NamedKey::Space)
+    ) {
+        return (false, Vec::new());
+    }
+
+    let Some(focused_id) = dom.focused_node else {
+        return (false, Vec::new());
+    };
+    let Some(node) = dom.nodes.get(focused_id) else {
+        return (false, Vec::new());
+    };
+    if node.is_text_input() || node.is_checkbox_input() || !node.is_focusable() {
+        return (false, Vec::new());
+    }
+
+    // Synthetic click: use the element's bounds center if we have a hitbox,
+    // otherwise (0, 0). The JS handler usually doesn't depend on coords for
+    // keyboard activations.
+    let (x, y) = node
+        .interactivity
+        .hitbox_id
+        .and_then(|hid| dom.hitbox_store.get(hid))
+        .map(|hb| {
+            (
+                (hb.bounds.x + hb.bounds.width / 2.0) as f32,
+                (hb.bounds.y + hb.bounds.height / 2.0) as f32,
+            )
+        })
+        .unwrap_or((0.0, 0.0));
+
+    dom.dispatch_click(x as f64, y as f64, crate::interactivity::MouseButton::Left);
+
+    (
+        true,
+        vec![AppEvent::Click(MouseEventData {
+            window_id: wid,
+            node_id: focused_id,
+            x,
+            y,
+            screen_x: x,
+            screen_y: y,
+            button: 0,
+            buttons: 0,
+        })],
+    )
+}
+
 pub struct TabFocusOutcome {
     pub consumed: bool,
     pub needs_redraw: bool,
     pub events: Vec<AppEvent>,
 }
 
-/// Handle Tab to advance focus to the next focusable element. Tab is always
-/// consumed (never inserts a tab character into a focused input).
+/// Handle Tab/Shift-Tab to advance focus to the next/previous focusable
+/// element. Tab is always consumed (never inserts a tab character).
 pub fn handle_tab_focus(
     dom: &mut UIState,
     wid: u32,
     key_event: &winit::event::KeyEvent,
+    modifiers: u32,
 ) -> TabFocusOutcome {
     use winit::event::ElementState;
 
@@ -1123,7 +1186,13 @@ pub fn handle_tab_focus(
 
     outcome.consumed = true;
 
-    if let Some(change) = dom.focus_next_node() {
+    let shift = modifiers & 4 != 0;
+    let change = if shift {
+        dom.focus_prev_node()
+    } else {
+        dom.focus_next_node()
+    };
+    if let Some(change) = change {
         if let Some(old) = change.old {
             outcome.events.push(AppEvent::Blur(FocusEventData {
                 window_id: wid,

--- a/crates/uzumaki/src/input.rs
+++ b/crates/uzumaki/src/input.rs
@@ -601,10 +601,6 @@ impl InputState {
                     Some(edit) => KeyResult::Edit(edit),
                     None => KeyResult::Ignored,
                 },
-                NamedKey::Tab => match self.insert_text("    ", renderer) {
-                    Some(edit) => KeyResult::Edit(edit),
-                    None => KeyResult::Ignored,
-                },
                 _ => KeyResult::Ignored,
             },
             _ => KeyResult::Ignored,

--- a/crates/uzumaki/src/interactivity.rs
+++ b/crates/uzumaki/src/interactivity.rs
@@ -181,6 +181,8 @@ pub struct Interactivity {
     pub hover_style: Option<Box<UzStyleRefinement>>,
     /// Applied when the element's hitbox is active (mouse pressed on it).
     pub active_style: Option<Box<UzStyleRefinement>>,
+    /// Applied when the element has keyboard focus.
+    pub focus_style: Option<Box<UzStyleRefinement>>,
 
     /// The hitbox ID assigned to this element during paint. None if not interactive.
     pub hitbox_id: Option<HitboxId>,
@@ -205,18 +207,21 @@ impl Interactivity {
         self.js_interactive
             || self.hover_style.is_some()
             || self.active_style.is_some()
+            || self.focus_style.is_some()
             || !self.mouse_down_listeners.is_empty()
             || !self.mouse_up_listeners.is_empty()
             || !self.click_listeners.is_empty()
     }
 
     /// Compute the final Style for this element by starting with the base style
-    /// and refining with hover/active styles based on the current hit test state.
+    /// and refining with hover/active/focus styles based on interaction state.
+    /// `focused` should be true iff this node currently holds keyboard focus.
     pub fn compute_style(
         &self,
         base: &UzStyle,
         node_id: UzNodeId,
         hit_state: &HitTestState,
+        focused: bool,
     ) -> UzStyle {
         let mut style = base.clone();
 
@@ -237,6 +242,16 @@ impl Interactivity {
             style.refine(active);
         }
 
+        if focused && let Some(focus) = &self.focus_style {
+            style.refine(focus);
+        }
+
+        // Default focus ring when focused and no explicit outline was set
+        // anywhere in the cascade.
+        if focused && style.outline.is_none() {
+            style.outline = Some(crate::style::Outline::FOCUS_RING);
+        }
+
         style
     }
 
@@ -246,6 +261,7 @@ impl Interactivity {
         parent: &UzStyle,
         node_id: UzNodeId,
         hit_state: &HitTestState,
+        focused: bool,
     ) -> UzStyle {
         let mut style = base.clone();
         style.inherit_from(parent);
@@ -263,6 +279,14 @@ impl Interactivity {
             style.refine(active);
         }
 
+        if focused && let Some(focus) = &self.focus_style {
+            style.refine(focus);
+        }
+
+        if focused && style.outline.is_none() {
+            style.outline = Some(crate::style::Outline::FOCUS_RING);
+        }
+
         style
     }
 
@@ -274,6 +298,11 @@ impl Interactivity {
     /// Set the active (pressed) style refinement.
     pub fn on_active(&mut self, style: UzStyleRefinement) {
         self.active_style = Some(Box::new(style));
+    }
+
+    /// Set the focus style refinement.
+    pub fn on_focus(&mut self, style: UzStyleRefinement) {
+        self.focus_style = Some(Box::new(style));
     }
 
     /// Add a click listener.

--- a/crates/uzumaki/src/ops/dom.rs
+++ b/crates/uzumaki/src/ops/dom.rs
@@ -43,7 +43,13 @@ pub fn op_create_element(
         } else if element_type == "text" {
             entry.dom.create_text(String::new(), style)
         } else {
-            entry.dom.create_view(style)
+            let id = entry.dom.create_view(style);
+            if element_type == "button"
+                && let Some(el) = entry.dom.nodes[id].as_element_mut()
+            {
+                el.set_focussable(true);
+            }
+            id
         };
         Ok(id as u32)
     })

--- a/crates/uzumaki/src/ops/style_util.rs
+++ b/crates/uzumaki/src/ops/style_util.rs
@@ -523,6 +523,10 @@ fn get_or_init_variant_style(node: &mut Node, variant: StyleVariant) -> &mut UzS
             .interactivity
             .active_style
             .get_or_insert_with(|| Box::new(UzStyleRefinement::default())),
+        StyleVariant::Focus => node
+            .interactivity
+            .focus_style
+            .get_or_insert_with(|| Box::new(UzStyleRefinement::default())),
         StyleVariant::Base => unreachable!(),
     }
 }
@@ -538,6 +542,10 @@ fn set_variant_color(
         StyleProp::Bg => r.background = Some(color),
         StyleProp::Color => r.text.color = Some(color),
         StyleProp::BorderColor => r.border_color = Some(color),
+        StyleProp::OutlineColor => {
+            let outline = r.outline.get_or_insert(Outline::FOCUS_RING);
+            outline.color = color;
+        }
         _ => return StyleEffect::Ignored,
     }
     StyleEffect::Applied
@@ -725,6 +733,14 @@ fn set_variant_number(
         StyleProp::BorderRight => r.border_widths.right = Some(value),
         StyleProp::BorderBottom => r.border_widths.bottom = Some(value),
         StyleProp::BorderLeft => r.border_widths.left = Some(value),
+        StyleProp::Outline => {
+            let outline = r.outline.get_or_insert(Outline::FOCUS_RING);
+            outline.width = value;
+        }
+        StyleProp::OutlineOffset => {
+            let outline = r.outline.get_or_insert(Outline::FOCUS_RING);
+            outline.offset = value;
+        }
         StyleProp::Opacity => r.opacity = Some(value),
         StyleProp::Visibility => {
             r.visibility = Some(if value > 0.5 {
@@ -877,6 +893,7 @@ fn clear_variant_prop(node: &mut Node, prop: StyleProp, variant: StyleVariant) -
     let style = match variant {
         StyleVariant::Hover => node.interactivity.hover_style.as_mut(),
         StyleVariant::Active => node.interactivity.active_style.as_mut(),
+        StyleVariant::Focus => node.interactivity.focus_style.as_mut(),
         StyleVariant::Base => unreachable!(),
     };
     if let Some(style) = style {
@@ -937,6 +954,9 @@ fn clear_variant_prop(node: &mut Node, prop: StyleProp, variant: StyleVariant) -
             StyleProp::BorderLeft => style.border_widths.left = None,
             StyleProp::Opacity => style.opacity = None,
             StyleProp::BorderColor => style.border_color = None,
+            StyleProp::Outline | StyleProp::OutlineColor | StyleProp::OutlineOffset => {
+                style.outline = None;
+            }
             StyleProp::Display => style.display = None,
             StyleProp::Cursor => style.cursor = None,
             StyleProp::Interactive => {}
@@ -1008,6 +1028,11 @@ fn set_color_style_prop(node: &mut Node, prop: StyleProp, color: Color) -> Style
         StyleProp::BorderColor => {
             node.style.border_color = Some(color);
             StyleEffect::AppliedNeedsSync
+        }
+        StyleProp::OutlineColor => {
+            let outline = node.style.outline.get_or_insert(Outline::FOCUS_RING);
+            outline.color = color;
+            StyleEffect::Applied
         }
         _ => StyleEffect::Ignored,
     }
@@ -1124,6 +1149,14 @@ fn set_f32_style_prop(node: &mut Node, prop: StyleProp, v: f32) -> StyleEffect {
         StyleProp::BorderRight => style.border_widths.right = v,
         StyleProp::BorderBottom => style.border_widths.bottom = v,
         StyleProp::BorderLeft => style.border_widths.left = v,
+        StyleProp::Outline => {
+            let outline = style.outline.get_or_insert(Outline::FOCUS_RING);
+            outline.width = v;
+        }
+        StyleProp::OutlineOffset => {
+            let outline = style.outline.get_or_insert(Outline::FOCUS_RING);
+            outline.offset = v;
+        }
         StyleProp::Opacity => style.opacity = v,
         StyleProp::Visibility => {
             style.visibility = if v > 0.5 {
@@ -1344,6 +1377,9 @@ fn clear_style_prop(node: &mut Node, prop: StyleProp, variant: StyleVariant) -> 
         StyleProp::BorderBottom => node.style.border_widths.bottom = default.border_widths.bottom,
         StyleProp::BorderLeft => node.style.border_widths.left = default.border_widths.left,
         StyleProp::BorderColor => node.style.border_color = default.border_color,
+        StyleProp::Outline | StyleProp::OutlineColor | StyleProp::OutlineOffset => {
+            node.style.outline = default.outline;
+        }
         StyleProp::Opacity => node.style.opacity = default.opacity,
         StyleProp::TranslateX => node.style.transform.translate_x = default.transform.translate_x,
         StyleProp::TranslateY => node.style.transform.translate_y = default.transform.translate_y,
@@ -1406,6 +1442,15 @@ fn get_style_prop(node: &Node, prop: StyleProp) -> Value {
         StyleProp::Bg => style.background.map(color_to_json).unwrap_or(Value::Null),
         StyleProp::Color => color_to_json(style.text.color),
         StyleProp::BorderColor => style.border_color.map(color_to_json).unwrap_or(Value::Null),
+        StyleProp::Outline => style.outline.map(|o| json!(o.width)).unwrap_or(Value::Null),
+        StyleProp::OutlineColor => style
+            .outline
+            .map(|o| color_to_json(o.color))
+            .unwrap_or(Value::Null),
+        StyleProp::OutlineOffset => style
+            .outline
+            .map(|o| json!(o.offset))
+            .unwrap_or(Value::Null),
         StyleProp::Opacity => json!(style.opacity),
         StyleProp::Visibility => json!(matches!(style.visibility, Visibility::Visible)),
         StyleProp::Scrollable => json!(matches!(style.overflow_y, Overflow::Scroll)),

--- a/crates/uzumaki/src/prop_keys.rs
+++ b/crates/uzumaki/src/prop_keys.rs
@@ -5,6 +5,7 @@ pub(crate) enum StyleVariant {
     Base,
     Hover,
     Active,
+    Focus,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -49,6 +50,9 @@ pub(crate) enum StyleProp {
     BorderBottom,
     BorderLeft,
     BorderColor,
+    Outline,
+    OutlineColor,
+    OutlineOffset,
     Opacity,
     Display,
     Cursor,
@@ -106,6 +110,11 @@ impl FromStr for AttributeKind {
                 .parse::<StyleProp>()
                 .map(|p| AttributeKind::Style(p, StyleVariant::Active));
         }
+        if let Some(rest) = value.strip_prefix("focus:") {
+            return rest
+                .parse::<StyleProp>()
+                .map(|p| AttributeKind::Style(p, StyleVariant::Focus));
+        }
 
         value
             .parse::<StyleProp>()
@@ -158,6 +167,9 @@ impl FromStr for StyleProp {
             "borderBottom" => Self::BorderBottom,
             "borderLeft" => Self::BorderLeft,
             "borderColor" => Self::BorderColor,
+            "outline" => Self::Outline,
+            "outlineColor" => Self::OutlineColor,
+            "outlineOffset" => Self::OutlineOffset,
             "opacity" => Self::Opacity,
             "display" => Self::Display,
             "cursor" => Self::Cursor,

--- a/crates/uzumaki/src/style.rs
+++ b/crates/uzumaki/src/style.rs
@@ -163,6 +163,25 @@ pub struct BoxShadow {
     pub spread_radius: f32,
 }
 
+/// Focus/decoration outline. Painted outside the element bounds, doesn't affect
+/// layout. `offset` is the gap between border edge and outline; the outline is
+/// stroked at `width` outside that.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Outline {
+    pub color: Color,
+    pub width: f32,
+    pub offset: f32,
+}
+
+impl Outline {
+    /// Default focus ring used when a focused element has no explicit outline.
+    pub const FOCUS_RING: Self = Self {
+        color: Color::rgba(86, 156, 214, 255),
+        width: 2.0,
+        offset: 2.0,
+    };
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub enum Length {
     #[default]
@@ -514,6 +533,7 @@ pub struct UzStyle {
     pub corner_radii: Corners,
     pub opacity: f32,
     pub box_shadow: Option<BoxShadow>,
+    pub outline: Option<Outline>,
 
     pub cursor: Option<UzCursorIcon>,
 
@@ -564,6 +584,7 @@ impl Default for UzStyle {
             corner_radii: Corners::default(),
             opacity: 1.0,
             box_shadow: None,
+            outline: None,
 
             cursor: None,
 
@@ -736,6 +757,48 @@ impl UzStyle {
             } else {
                 self.paint_rect_borders(bounds, scene, vbc, transform);
             }
+        }
+
+        // 5. Outline (drawn outside the box, doesn't affect layout)
+        if let Some(outline) = self.outline
+            && outline.width > 0.0
+            && !outline.color.is_transparent()
+        {
+            self.paint_outline(bounds, scene, outline, opacity, transform);
+        }
+    }
+
+    fn paint_outline(
+        &self,
+        bounds: Bounds,
+        scene: &mut Scene,
+        outline: Outline,
+        opacity: f32,
+        transform: Affine,
+    ) {
+        let color = outline.color.with_opacity(opacity).to_vello();
+        // Stroke is centered on the path, so push the path outward by
+        // `offset + width/2` to land its inner edge `offset` away from the box.
+        let inset = -(outline.offset as f64 + outline.width as f64 / 2.0);
+        let outer = Bounds::new(
+            bounds.x + inset,
+            bounds.y + inset,
+            bounds.width - 2.0 * inset,
+            bounds.height - 2.0 * inset,
+        );
+        let stroke = Stroke::new(outline.width as f64);
+        if self.corner_radii.any_nonzero() {
+            let grow = outline.offset + outline.width / 2.0;
+            let grown = Corners {
+                top_left: (self.corner_radii.top_left + grow).max(0.0),
+                top_right: (self.corner_radii.top_right + grow).max(0.0),
+                bottom_right: (self.corner_radii.bottom_right + grow).max(0.0),
+                bottom_left: (self.corner_radii.bottom_left + grow).max(0.0),
+            };
+            let shape = rounded_rect(outer, &grown);
+            scene.stroke(&stroke, transform, color, None, &shape);
+        } else {
+            scene.stroke(&stroke, transform, color, None, &outer.to_rect());
         }
     }
 

--- a/crates/uzumaki/src/ui.rs
+++ b/crates/uzumaki/src/ui.rs
@@ -111,9 +111,12 @@ impl UIState {
             return UzCursorIcon::Default;
         };
 
-        let style = node
-            .interactivity
-            .compute_style(&node.style, node_id, &self.hit_state);
+        let style = node.interactivity.compute_style(
+            &node.style,
+            node_id,
+            &self.hit_state,
+            self.focused_node == Some(node_id),
+        );
         if let Some(c) = style.cursor {
             return c;
         }
@@ -129,7 +132,12 @@ impl UIState {
         let mut cur = node.parent;
         while let Some(id) = cur {
             let n = &self.nodes[id];
-            let style = n.interactivity.compute_style(&n.style, id, &self.hit_state);
+            let style = n.interactivity.compute_style(
+                &n.style,
+                id,
+                &self.hit_state,
+                self.focused_node == Some(id),
+            );
             if let Some(c) = style.cursor {
                 return c;
             }
@@ -574,8 +582,13 @@ impl UIState {
     pub(crate) fn computed_style(&self, node_id: UzNodeId, parent: Option<&UzStyle>) -> UzStyle {
         let node = &self.nodes[node_id];
         let parent = parent.unwrap_or(&node.style);
-        node.interactivity
-            .compute_style_inherited(&node.style, parent, node_id, &self.hit_state)
+        node.interactivity.compute_style_inherited(
+            &node.style,
+            parent,
+            node_id,
+            &self.hit_state,
+            self.focused_node == Some(node_id),
+        )
     }
 
     fn collect_computed_styles(

--- a/crates/uzumaki/src/ui.rs
+++ b/crates/uzumaki/src/ui.rs
@@ -217,6 +217,10 @@ impl UIState {
             .unwrap();
         // Input always needs a hitbox for click-to-focus
         self.nodes[node_id].interactivity.js_interactive = true;
+        self.nodes[node_id]
+            .as_element_mut()
+            .expect("input should be an element")
+            .set_focussable(true);
         node_id
     }
 

--- a/packages/playground/src/pages/inputsPage.tsx
+++ b/packages/playground/src/pages/inputsPage.tsx
@@ -10,6 +10,11 @@ export function InputsPage() {
   const [bio, setBio] = useState('');
   const [search, setSearch] = useState('');
   const [submitted, setSubmitted] = useState(false);
+
+  const [noRounding, setNoRounding] = useState(false);
+  const [rounded, setRounded] = useState(true);
+  const [circle, setCircle] = useState(false);
+
   const inputPadding = 8;
 
   const pwMatch = password === confirm && confirm.length > 0;
@@ -175,7 +180,7 @@ export function InputsPage() {
             value={bio}
             onChangeText={setBio}
             placeholder="Tell us about yourself... (multiline input, try pasting long text)"
-            fontSize={14}
+            fontSize={16}
             color={C.text}
             bg={C.surface2}
             p={12}
@@ -257,6 +262,69 @@ export function InputsPage() {
 
         <Divider />
 
+        <view display="flex" flexDir="col" gap={12}>
+          <text fontSize={14} fontWeight={700} color={C.text}>
+            Checkboxes
+          </text>
+          <view
+            display="flex"
+            flexDir="col"
+            p={16}
+            gap={14}
+            bg={C.surface2}
+            rounded={8}
+            border={1}
+            borderColor={C.border}
+          >
+            <view display="flex" items="center" gap={12}>
+              <checkbox
+                checked={noRounding}
+                onChange={setNoRounding}
+                bg={C.accent}
+                borderColor={noRounding ? C.accent : C.border}
+                color="#ffffff"
+                w={20}
+                h={20}
+                hover:opacity={0.9}
+              />
+              <text fontSize={14} color={C.text}>
+                Square checkbox{noRounding ? ' [selected]' : ''}
+              </text>
+            </view>
+            <view display="flex" items="center" gap={12}>
+              <checkbox
+                checked={rounded}
+                onChange={setRounded}
+                bg={C.success}
+                borderColor={rounded ? C.success : C.border}
+                color="#08110a"
+                rounded={4}
+                w={20}
+                h={20}
+              />
+              <text fontSize={14} color={C.text}>
+                Rounded checkbox{rounded ? ' [selected]' : ''}
+              </text>
+            </view>
+            <view display="flex" items="center" gap={12}>
+              <checkbox
+                checked={circle}
+                onChange={setCircle}
+                bg={C.warning}
+                borderColor={circle ? C.warning : C.border}
+                color="#1b1104"
+                rounded={10}
+                w={20}
+                h={20}
+              />
+              <text fontSize={14} color={C.text}>
+                Circular checkbox{circle ? ' [selected]' : ''}
+              </text>
+            </view>
+          </view>
+        </view>
+        <Divider />
+
         <view display="flex" flexDir="col" gap={8}>
           <view display="flex" flexDir="row" items="center" gap={8}>
             <text fontSize={13} fontWeight={600} color={C.textSub}>
@@ -271,14 +339,12 @@ export function InputsPage() {
             rounded={8}
             border={1}
             borderColor={C.borderHi}
-            overflowX="hidden"
           >
             <text fontSize={13} color={C.textDim} w="100%">
               The quick brown fox jumps over the lazy dog. Pack my box with five
               dozen liquor jugs. How valiantly the strong and quick brown fox
               leaps over the sleeping lazy hound dog! Try selecting this text
-              with your mouse — this tests the selectable prop and focus element
-              behavior.
+              with your mouse.
             </text>
           </view>
         </view>

--- a/packages/playground/src/pages/layoutPage.tsx
+++ b/packages/playground/src/pages/layoutPage.tsx
@@ -128,9 +128,6 @@ export function LayoutPage() {
   const [showDisplay, setShowDisplay] = useState(false);
   const [gap, setGap] = useState(8);
   const [padding, setPadding] = useState(12);
-  const [noRounding, setNoRounding] = useState(false);
-  const [rounded, setRounded] = useState(true);
-  const [circle, setCircle] = useState(false);
 
   return (
     <view display="flex" flexDir="col" gap={0} h="full" scrollable>
@@ -721,70 +718,6 @@ export function LayoutPage() {
               </view>
 
               <view flex={1} />
-            </view>
-          </view>
-        </view>
-
-        <Divider />
-
-        <view display="flex" flexDir="col" gap={12}>
-          <text fontSize={14} fontWeight={700} color={C.text}>
-            Checkboxes
-          </text>
-          <view
-            display="flex"
-            flexDir="col"
-            p={16}
-            gap={14}
-            bg={C.surface2}
-            rounded={8}
-            border={1}
-            borderColor={C.border}
-          >
-            <view display="flex" items="center" gap={12}>
-              <checkbox
-                checked={noRounding}
-                onChange={setNoRounding}
-                bg={C.accent}
-                borderColor={noRounding ? C.accent : C.border}
-                color="#ffffff"
-                w={20}
-                h={20}
-                hover:opacity={0.9}
-              />
-              <text fontSize={14} color={C.text}>
-                Square checkbox{noRounding ? ' [selected]' : ''}
-              </text>
-            </view>
-            <view display="flex" items="center" gap={12}>
-              <checkbox
-                checked={rounded}
-                onChange={setRounded}
-                bg={C.success}
-                borderColor={rounded ? C.success : C.border}
-                color="#08110a"
-                rounded={4}
-                w={20}
-                h={20}
-              />
-              <text fontSize={14} color={C.text}>
-                Rounded checkbox{rounded ? ' [selected]' : ''}
-              </text>
-            </view>
-            <view display="flex" items="center" gap={12}>
-              <checkbox
-                checked={circle}
-                onChange={setCircle}
-                bg={C.warning}
-                borderColor={circle ? C.warning : C.border}
-                color="#1b1104"
-                rounded={10}
-                w={20}
-                h={20}
-              />
-              <text fontSize={14} color={C.text}>
-                Circular checkbox{circle ? ' [selected]' : ''}
-              </text>
             </view>
           </view>
         </view>

--- a/packages/playground/src/sidebar.tsx
+++ b/packages/playground/src/sidebar.tsx
@@ -53,7 +53,7 @@ export function Sidebar({
           const isActive = active === t.id;
           const iconColor = isActive ? C.accentHi : C.textMuted;
           return (
-            <view
+            <button
               key={t.id}
               onClick={() => setActive(t.id)}
               display="flex"
@@ -81,7 +81,7 @@ export function Sidebar({
                 </text>
               </view>
               {isActive && <view w={4} h={4} bg={C.accentHi} rounded={4} />}
-            </view>
+            </button>
           );
         })}
         <button


### PR DESCRIPTION
## Description

closes #8 
### new features
- focus next or previous elements with `Tab` and `Shift` + `Tab`
- focus styles
- outline styles

## Checklist

- [x] I have run `cargo fmt` and `pnpm format`
- [x] I have run `cargo clippy --workspace -D warnings` and `pnpm lint` with no errors
- [x] I have manually tested my changes
- [x] This PR is focused on a single scope — no unrelated drive-by changes
- [x] If this PR uses AI-generated code, I have thoroughly reviewed and tested every line myself
