### PR TITLE
feat: add runtime Theme Vars API (#66)

### DIFF
--- a/crates/uzumaki/core/runtime.js
+++ b/crates/uzumaki/core/runtime.js
@@ -1,5 +1,6 @@
 import {
   op_create_window,
+  op_set_window_vars,
   op_request_quit,
   op_request_redraw,
   op_get_root_node,
@@ -21,6 +22,7 @@ import {
 Object.defineProperty(globalThis, '__uzumaki_ops_dont_touch_this__', {
   value: Object.freeze({
     createWindow: op_create_window,
+    setWindowVars: op_set_window_vars,
     requestQuit: op_request_quit,
     requestRedraw: op_request_redraw,
     getRootNode: op_get_root_node,

--- a/crates/uzumaki/js/core.ts
+++ b/crates/uzumaki/js/core.ts
@@ -36,7 +36,9 @@ interface Core {
     width: number;
     height: number;
     title: string;
+    vars?: Record<string, unknown>;
   }): CoreWindow;
+  setWindowVars(windowId: number, vars: Record<string, unknown>): void;
   requestQuit(): void;
   requestRedraw(windowId: number): void;
   getRootNode(windowId: number): CoreNode;

--- a/crates/uzumaki/js/index.ts
+++ b/crates/uzumaki/js/index.ts
@@ -1,5 +1,6 @@
 import { eventManager, EventType } from './events';
 import { disposeWindow, Window } from './window';
+export { defineVars } from './theme';
 
 export { Window } from './window';
 export { UzNode, UzTextNode } from './node';
@@ -7,6 +8,7 @@ export { Element } from './elements/element';
 export { UzElement } from './elements/base';
 export { UzRootElement } from './elements/root';
 export { UzImageElement } from './elements/image';
+export { getWindow } from './window';
 export { Clipboard } from './clipboard';
 export { eventManager, EventType } from './events';
 export type {

--- a/crates/uzumaki/js/theme.ts
+++ b/crates/uzumaki/js/theme.ts
@@ -1,0 +1,16 @@
+export type ThemeRefs<T extends Record<string, unknown>> = {
+  [K in keyof T]: `$${Extract<K, string>}`;
+};
+
+export function defineVars<const T extends Record<string, unknown>>(
+  tokens: T,
+): {
+  vars: T;
+  theme: ThemeRefs<T>;
+} {
+  const theme = Object.fromEntries(
+    Object.keys(tokens).map((k) => [k, `$${k}`]),
+  ) as ThemeRefs<T>;
+
+  return { vars: tokens, theme };
+}

--- a/crates/uzumaki/js/window.ts
+++ b/crates/uzumaki/js/window.ts
@@ -20,6 +20,7 @@ export interface WindowAttributes {
   height: number;
   title: string;
   rootStyles: Record<string, unknown>;
+  vars?: Record<string, unknown>;
 }
 
 export class Window {
@@ -41,6 +42,7 @@ export class Window {
       height = 600,
       title = 'uzumaki',
       rootStyles,
+      vars,
     }: Partial<WindowAttributes> = {},
   ) {
     const existing = windowsByLabel.get(label);
@@ -52,7 +54,10 @@ export class Window {
     this._height = height;
     this._label = label;
     this._title = title;
-    this._native = core.createWindow({ width, height, title });
+    this._native =
+      vars == null
+        ? core.createWindow({ width, height, title })
+        : core.createWindow({ width, height, title, vars });
     this._id = this._native.id;
     if (rootStyles) {
       const root = this.root;
@@ -62,6 +67,10 @@ export class Window {
     }
     windowsByLabel.set(label, this);
     windowsById.set(this._id, this);
+  }
+
+  setVars(vars: Record<string, unknown>): void {
+    core.setWindowVars(this._id, vars);
   }
 
   close() {
@@ -190,4 +199,12 @@ export function disposeWindow(_window: Window) {
   eventManager.clearWindowHandlers(window.id);
   windowsByLabel.delete(window.label);
   windowsById.delete(window.id);
+}
+
+export function getWindow(label: string): Window {
+  const window = windowsByLabel.get(label);
+  if (!window) {
+    throw new Error(`Window with label ${label} not found`);
+  }
+  return window;
 }

--- a/crates/uzumaki/src/app.rs
+++ b/crates/uzumaki/src/app.rs
@@ -22,6 +22,7 @@ use deno_runtime::deno_web::{BlobStore, InMemoryBroadcastChannel};
 use deno_runtime::worker::{MainWorker, WorkerOptions, WorkerServiceOptions};
 use node_resolver::analyze::{CjsModuleExportAnalyzer, NodeCodeTranslator, NodeCodeTranslatorMode};
 use node_resolver::cache::NodeResolutionSys;
+use serde_json::Value;
 use winit::window::WindowId;
 use winit::{application::ApplicationHandler, event::WindowEvent};
 
@@ -40,6 +41,8 @@ pub struct WindowEntry {
     pub handle: Option<window::Window>,
     pub rem_base: f32,
     pub cursor_blink_generation: u64,
+    pub vars: HashMap<String, Value>,
+    pub bound_vars: HashMap<(crate::element::UzNodeId, String), String>,
 }
 
 impl WindowEntry {

--- a/crates/uzumaki/src/lib.rs
+++ b/crates/uzumaki/src/lib.rs
@@ -56,6 +56,7 @@ extension!(
   ops = [
     op_get_uz_runtime_version,
     op_create_window,
+    op_set_window_vars,
     op_request_quit,
     op_request_redraw,
     op_get_root_node,

--- a/crates/uzumaki/src/ops/dom.rs
+++ b/crates/uzumaki/src/ops/dom.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 use crate::app::{SharedAppState, with_state};
 use crate::element::UzNodeId;
 use crate::style::UzStyle;
-use crate::ui::UIState;
 
 fn window_not_found() -> deno_error::JsErrorBox {
     deno_error::JsErrorBox::new("WindowNotFound", "window not found")
@@ -77,29 +76,6 @@ unsafe impl GarbageCollected for CoreNode {
     fn get_name(&self) -> &'static std::ffi::CStr {
         c"CoreNode"
     }
-}
-
-fn collect_subtree_node_ids(dom: &UIState, root_id: UzNodeId) -> Vec<UzNodeId> {
-    if !dom.nodes.contains(root_id) {
-        return Vec::new();
-    }
-
-    let mut ids = Vec::new();
-    let mut stack = vec![root_id];
-
-    while let Some(nid) = stack.pop() {
-        ids.push(nid);
-        let Some(node) = dom.nodes.get(nid) else {
-            continue;
-        };
-        let mut child = node.first_child;
-        while let Some(cid) = child {
-            stack.push(cid);
-            child = dom.nodes.get(cid).and_then(|n| n.next_sibling);
-        }
-    }
-
-    ids
 }
 
 #[op2]
@@ -454,8 +430,6 @@ fn remove_child(
         let Some(entry) = s.windows.get_mut(&window_id) else {
             return Err(window_not_found());
         };
-        let removed_ids = collect_subtree_node_ids(&entry.dom, cid);
-        entry.remove_bound_vars_for_nodes(&removed_ids);
         entry.dom.remove_child(pid, cid);
         Ok(())
     })
@@ -545,16 +519,6 @@ pub fn op_reset_dom(
             return Err(window_not_found());
         };
         let root = entry.dom.root.expect("no root node");
-        let removed_ids = {
-            let mut ids = Vec::new();
-            let mut child = entry.dom.nodes[root].first_child;
-            while let Some(cid) = child {
-                ids.extend(collect_subtree_node_ids(&entry.dom, cid));
-                child = entry.dom.nodes[cid].next_sibling;
-            }
-            ids
-        };
-        entry.remove_bound_vars_for_nodes(&removed_ids);
         entry.dom.clear_children(root);
         Ok(())
     })

--- a/crates/uzumaki/src/ops/dom.rs
+++ b/crates/uzumaki/src/ops/dom.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use crate::app::{SharedAppState, with_state};
 use crate::element::UzNodeId;
 use crate::style::UzStyle;
+use crate::ui::UIState;
 
 fn window_not_found() -> deno_error::JsErrorBox {
     deno_error::JsErrorBox::new("WindowNotFound", "window not found")
@@ -76,6 +77,29 @@ unsafe impl GarbageCollected for CoreNode {
     fn get_name(&self) -> &'static std::ffi::CStr {
         c"CoreNode"
     }
+}
+
+fn collect_subtree_node_ids(dom: &UIState, root_id: UzNodeId) -> Vec<UzNodeId> {
+    if !dom.nodes.contains(root_id) {
+        return Vec::new();
+    }
+
+    let mut ids = Vec::new();
+    let mut stack = vec![root_id];
+
+    while let Some(nid) = stack.pop() {
+        ids.push(nid);
+        let Some(node) = dom.nodes.get(nid) else {
+            continue;
+        };
+        let mut child = node.first_child;
+        while let Some(cid) = child {
+            stack.push(cid);
+            child = dom.nodes.get(cid).and_then(|n| n.next_sibling);
+        }
+    }
+
+    ids
 }
 
 #[op2]
@@ -430,6 +454,8 @@ fn remove_child(
         let Some(entry) = s.windows.get_mut(&window_id) else {
             return Err(window_not_found());
         };
+        let removed_ids = collect_subtree_node_ids(&entry.dom, cid);
+        entry.remove_bound_vars_for_nodes(&removed_ids);
         entry.dom.remove_child(pid, cid);
         Ok(())
     })
@@ -519,6 +545,16 @@ pub fn op_reset_dom(
             return Err(window_not_found());
         };
         let root = entry.dom.root.expect("no root node");
+        let removed_ids = {
+            let mut ids = Vec::new();
+            let mut child = entry.dom.nodes[root].first_child;
+            while let Some(cid) = child {
+                ids.extend(collect_subtree_node_ids(&entry.dom, cid));
+                child = entry.dom.nodes[cid].next_sibling;
+            }
+            ids
+        };
+        entry.remove_bound_vars_for_nodes(&removed_ids);
         entry.dom.clear_children(root);
         Ok(())
     })

--- a/crates/uzumaki/src/ops/style_util.rs
+++ b/crates/uzumaki/src/ops/style_util.rs
@@ -10,6 +10,15 @@ use crate::ui::UIState;
 use crate::parse::*;
 
 impl WindowEntry {
+    pub fn remove_bound_vars_for_nodes(&mut self, node_ids: &[UzNodeId]) {
+        if node_ids.is_empty() {
+            return;
+        }
+        let ids: std::collections::HashSet<UzNodeId> = node_ids.iter().copied().collect();
+        self.bound_vars
+            .retain(|(node_id, _), _| !ids.contains(node_id));
+    }
+
     pub fn set_str_attribute(&mut self, node_id: UzNodeId, name: &str, value: &str) {
         let Some(kind) = name.parse::<AttributeKind>().ok() else {
             return;
@@ -17,16 +26,31 @@ impl WindowEntry {
 
         let effect = match kind {
             AttributeKind::Element(ep) => {
+                self.bound_vars.remove(&(node_id, name.to_string()));
                 let Some(node) = self.dom.nodes.get_mut(node_id) else {
                     return;
                 };
                 set_element_str(node, ep, value, self.rem_base)
             }
             AttributeKind::Style(prop, variant) => {
+                let Some(var_name) = parse_var_reference(value) else {
+                    self.bound_vars.remove(&(node_id, name.to_string()));
+                    let Some(node) = self.dom.nodes.get_mut(node_id) else {
+                        return;
+                    };
+                    let effect = set_style_str(node, prop, variant, value, self.rem_base);
+                    self.apply_side_effects(node_id, &kind, effect);
+                    return;
+                };
+
+                self.bound_vars
+                    .insert((node_id, name.to_string()), var_name.to_string());
+
+                let var_value = self.vars.get(var_name).cloned();
                 let Some(node) = self.dom.nodes.get_mut(node_id) else {
                     return;
                 };
-                set_style_str(node, prop, variant, value, self.rem_base)
+                apply_var_to_style(node, prop, variant, var_value.as_ref(), self.rem_base)
             }
         };
 
@@ -37,6 +61,8 @@ impl WindowEntry {
         let Some(kind) = name.parse::<AttributeKind>().ok() else {
             return;
         };
+
+        self.bound_vars.remove(&(node_id, name.to_string()));
 
         let effect = match kind {
             AttributeKind::Element(ep) => {
@@ -61,6 +87,8 @@ impl WindowEntry {
             return;
         };
 
+        self.bound_vars.remove(&(node_id, name.to_string()));
+
         let effect = match kind {
             AttributeKind::Element(ep) => {
                 let Some(node) = self.dom.nodes.get_mut(node_id) else {
@@ -83,6 +111,8 @@ impl WindowEntry {
         let Some(kind) = name.parse::<AttributeKind>().ok() else {
             return;
         };
+
+        self.bound_vars.remove(&(node_id, name.to_string()));
 
         let effect = match kind {
             AttributeKind::Element(ep) => {
@@ -117,6 +147,48 @@ impl WindowEntry {
         }
     }
 
+    pub fn set_vars(&mut self, vars: std::collections::HashMap<String, Value>) {
+        self.vars = vars;
+        self.reapply_bound_vars();
+        if let Some(handle) = self.handle.as_ref() {
+            handle.winit_window.request_redraw();
+        }
+    }
+
+    fn reapply_bound_vars(&mut self) {
+        let bindings: Vec<(UzNodeId, String, String)> = self
+            .bound_vars
+            .iter()
+            .map(|((node_id, attr_name), var_name)| (*node_id, attr_name.clone(), var_name.clone()))
+            .collect();
+
+        for (node_id, attr_name, var_name) in bindings {
+            if !self.dom.nodes.contains(node_id) {
+                self.bound_vars.remove(&(node_id, attr_name));
+                continue;
+            }
+
+            let Ok(kind) = attr_name.parse::<AttributeKind>() else {
+                self.bound_vars.remove(&(node_id, attr_name));
+                continue;
+            };
+
+            let effect = match kind {
+                AttributeKind::Style(prop, variant) => {
+                    let value = self.vars.get(var_name.as_str()).cloned();
+                    let Some(node) = self.dom.nodes.get_mut(node_id) else {
+                        self.bound_vars.remove(&(node_id, attr_name));
+                        continue;
+                    };
+                    apply_var_to_style(node, prop, variant, value.as_ref(), self.rem_base)
+                }
+                AttributeKind::Element(_) => continue,
+            };
+
+            self.apply_side_effects(node_id, &kind, effect);
+        }
+    }
+
     fn apply_side_effects(&mut self, node_id: UzNodeId, kind: &AttributeKind, effect: StyleEffect) {
         if matches!(effect, StyleEffect::AppliedNeedsSync) {
             sync_taffy(&mut self.dom, node_id);
@@ -133,6 +205,32 @@ impl WindowEntry {
             let icon = self.dom.resolve_cursor(top);
             handle.set_cursor(icon);
         }
+    }
+}
+
+fn parse_var_reference(value: &str) -> Option<&str> {
+    let token = value.strip_prefix('$')?;
+    if token.is_empty() {
+        return None;
+    }
+    Some(token)
+}
+
+fn apply_var_to_style(
+    node: &mut Node,
+    prop: StyleProp,
+    variant: StyleVariant,
+    value: Option<&Value>,
+    rem_base: f32,
+) -> StyleEffect {
+    match value {
+        Some(Value::String(v)) => set_style_str(node, prop, variant, v, rem_base),
+        Some(Value::Number(v)) => v
+            .as_f64()
+            .map(|n| set_style_number(node, prop, variant, n as f32))
+            .unwrap_or_else(|| clear_style_prop(node, prop, variant)),
+        Some(Value::Bool(v)) => set_style_number(node, prop, variant, if *v { 1.0 } else { 0.0 }),
+        Some(_) | None => clear_style_prop(node, prop, variant),
     }
 }
 

--- a/crates/uzumaki/src/ops/window.rs
+++ b/crates/uzumaki/src/ops/window.rs
@@ -1,4 +1,6 @@
 use deno_core::*;
+use serde_json::Value;
+use std::collections::HashMap;
 use winit::event_loop::EventLoopProxy;
 
 use crate::app::{
@@ -12,6 +14,8 @@ struct CreateWindowOptions {
     width: u32,
     height: u32,
     title: String,
+    #[serde(default)]
+    vars: HashMap<String, Value>,
 }
 
 #[op2]
@@ -36,6 +40,8 @@ pub fn op_create_window(
                 handle: None,
                 rem_base: 16.0,
                 cursor_blink_generation: 0,
+                vars: options.vars,
+                bound_vars: HashMap::new(),
             },
         );
     });
@@ -56,6 +62,20 @@ pub fn op_create_window(
         })?;
 
     Ok(CoreWindow::new(id))
+}
+
+#[op2]
+pub fn op_set_window_vars(
+    state: &mut OpState,
+    #[smi] window_id: u32,
+    #[serde] vars: HashMap<String, Value>,
+) {
+    let app_state = state.borrow::<SharedAppState>().clone();
+    with_state(&app_state, |s| {
+        if let Some(entry) = s.windows.get_mut(&window_id) {
+            entry.set_vars(vars);
+        }
+    });
 }
 
 #[op2(fast)]

--- a/crates/uzumaki/tsconfig.json
+++ b/crates/uzumaki/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "types": ["uzumaki-types"],
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   }
 }

--- a/docs/src/content/docs/reference/window.md
+++ b/docs/src/content/docs/reference/window.md
@@ -34,10 +34,45 @@ render(window, <App />);
 
 ## Window options
 
-| Option   | Type     | Description                     |
-| -------- | -------- | ------------------------------- |
-| `width`  | `number` | Initial window width in pixels  |
-| `height` | `number` | Initial window height in pixels |
-| `title`  | `string` | Window title bar text           |
+| Option   | Type     | Description                                               |
+| -------- | -------- | --------------------------------------------------------- |
+| `width`  | `number` | Initial window width in pixels                            |
+| `height` | `number` | Initial window height in pixels                           |
+| `title`  | `string` | Window title bar text                                     |
+| `vars`   | `object` | Runtime theme variables resolved from `$token` style refs |
 
 The first argument to `new Window()` is a window identifier string (e.g. `'main'`).
+
+## Theme vars
+
+Use `vars` for values that should switch per theme at runtime. Component styles
+can reference these using `$token` values (for example from `defineVars(...)`).
+
+```tsx
+import { Window, defineVars, getWindow } from 'uzumaki-ui';
+
+const { vars: darkVars, theme: darkTheme } = defineVars({
+  bgBase: '#0f0f0f',
+  textPrimary: '#e4e4e7',
+});
+
+const { vars: lightVars } = defineVars({
+  bgBase: '#fafafa',
+  textPrimary: '#111111',
+});
+
+const window = new Window('main', {
+  width: 800,
+  height: 600,
+  title: 'Theme vars',
+  vars: darkVars,
+});
+
+// Later, switch theme vars without a React rerender.
+getWindow('main').setVars(lightVars);
+```
+
+`getWindow(label)` returns an existing window by label.
+
+`window.setVars(vars)` updates the window variable table used by Rust to resolve
+`$token` style values on the next frame.


### PR DESCRIPTION
## Summary
Implements Theme API #66 with runtime-resolved style vars and no-react-rerender theme switching.

## What was added
- Added  API that returns:
  - : raw token map for window runtime vars
  - : same keys mapped to  references
- Added window vars support on creation and runtime updates:
  - 
  - 
  - 
- Added native runtime op wiring for .
- Added Rust-side  style resolution and var binding re-apply on .
- Added cleanup of bound var references when nodes are removed/reset to prevent stale binding leaks from slab id reuse.
- Added docs for vars, , and  usage.
- Updated uzumaki package TypeScript config so package typecheck passes in this workspace setup.

## Behavior
- Constants remain plain JS values.
- Theme vars are resolved in Rust at style application time from window vars.
- Runtime theme switching works without React rerender:
  - 

## Validation
- : pass
- : pass
