### PR TITLE
fix: generalize element focus support

### DIFF
--- a/crates/uzumaki/core/runtime.js
+++ b/crates/uzumaki/core/runtime.js
@@ -11,7 +11,7 @@ import {
   op_clear_image_data,
   /** end image */
   op_reset_dom,
-  op_focus_input,
+  op_focus_element,
   op_get_ancestor_path,
   op_read_clipboard_text,
   op_write_clipboard_text,
@@ -30,7 +30,7 @@ Object.defineProperty(globalThis, '__uzumaki_ops_dont_touch_this__', {
     applyCachedImage: op_apply_cached_image,
     clearImageData: op_clear_image_data,
     resetDom: op_reset_dom,
-    focusInput: op_focus_input,
+    focusElement: op_focus_element,
     getAncestorPath: op_get_ancestor_path,
     readClipboardText: op_read_clipboard_text,
     writeClipboardText: op_write_clipboard_text,

--- a/crates/uzumaki/js/core.ts
+++ b/crates/uzumaki/js/core.ts
@@ -51,7 +51,7 @@ interface Core {
   applyCachedImage(windowId: number, nodeId: NodeId, cacheKey: string): boolean;
   clearImageData(windowId: number, nodeId: NodeId): void;
   resetDom(windowId: number): void;
-  focusInput(windowId: number, nodeId: NodeId): void;
+  focusElement(windowId: number, nodeId: NodeId): void;
   getAncestorPath(windowId: number, nodeId: NodeId): NodeId[];
   getSelection(windowId: number): SelectionState | null;
   getSelectedText(windowId: number): string;

--- a/crates/uzumaki/js/elements/element.ts
+++ b/crates/uzumaki/js/elements/element.ts
@@ -7,6 +7,10 @@ export class Element extends UzNode {
     super(window, native);
   }
 
+  focus(): void {
+    core.focusElement(this._window.id, this._native.id);
+  }
+
   setAttribute(name: string, value: unknown): void {
     if (value == null) {
       this.removeAttribute(name);

--- a/crates/uzumaki/js/react/jsx/types.ts
+++ b/crates/uzumaki/js/react/jsx/types.ts
@@ -104,7 +104,9 @@ type ActiveStyles = PrefixedStyles<'active'>;
 type FocusStyles = PrefixedStyles<'focus'>;
 
 interface ElementAttributes
-  extends ElementStyles, HoverStyles, ActiveStyles, FocusStyles {}
+  extends ElementStyles, HoverStyles, ActiveStyles, FocusStyles {
+  focusable?: boolean;
+}
 
 interface EventProps {
   onClick?: (ev: UzumakiMouseEvent) => void;

--- a/crates/uzumaki/src/element/selection.rs
+++ b/crates/uzumaki/src/element/selection.rs
@@ -152,9 +152,9 @@ impl UIState {
         self.text_selection = selection;
     }
 
-    /// Focus an input node. Clears any active view selection and blurs the
+    /// Focus an element node. Clears any active view selection and blurs the
     /// previously focused input.
-    pub fn focus_input(&mut self, node_id: UzNodeId) {
+    pub fn focus_element(&mut self, node_id: UzNodeId) {
         self.text_selection.clear();
         if let Some(old_id) = self.focused_node
             && old_id != node_id
@@ -288,7 +288,7 @@ impl UIState {
             .map(|n| n.is_text_input())
             .unwrap_or(false);
         if is_input {
-            self.focus_input(new_id);
+            self.focus_element(new_id);
         } else {
             self.clear_selection();
             self.focused_node = Some(new_id);

--- a/crates/uzumaki/src/event_dispatch.rs
+++ b/crates/uzumaki/src/event_dispatch.rs
@@ -689,7 +689,7 @@ pub fn handle_mouse_input(
                         };
                         let relative_y = (my - hb.y) as f32 + scroll_offset_y - top_pad;
 
-                        dom.focus_input(nid);
+                        dom.focus_element(nid);
 
                         // Apply styles/width so hit-testing accounts for wrapping
                         if let Some(meta) = input_layout_meta(dom, nid)

--- a/crates/uzumaki/src/lib.rs
+++ b/crates/uzumaki/src/lib.rs
@@ -65,7 +65,7 @@ extension!(
     op_apply_cached_image,
     op_clear_image_data,
     op_reset_dom,
-    op_focus_input,
+    op_focus_element,
     op_get_ancestor_path,
     op_get_selection,
     op_get_selected_text,

--- a/crates/uzumaki/src/ops/dom.rs
+++ b/crates/uzumaki/src/ops/dom.rs
@@ -525,7 +525,7 @@ pub fn op_reset_dom(
 }
 
 #[op2(fast)]
-pub fn op_focus_input(
+pub fn op_focus_element(
     state: &mut OpState,
     #[smi] window_id: u32,
     #[smi] node_id: u32,
@@ -536,7 +536,7 @@ pub fn op_focus_input(
         let Some(entry) = s.windows.get_mut(&window_id) else {
             return Err(window_not_found());
         };
-        entry.dom.focus_input(nid);
+        entry.dom.focus_element(nid);
         Ok(())
     })
 }

--- a/crates/uzumaki/src/ops/style_util.rs
+++ b/crates/uzumaki/src/ops/style_util.rs
@@ -165,7 +165,8 @@ fn set_element_str(node: &mut Node, prop: ElementProp, value: &str, _rem_base: f
         ElementProp::Disabled
         | ElementProp::Multiline
         | ElementProp::Secure
-        | ElementProp::Checked => {
+        | ElementProp::Checked
+        | ElementProp::Focusable => {
             return set_element_bool(node, prop, parse_bool(value));
         }
     }
@@ -183,7 +184,8 @@ fn set_element_number(node: &mut Node, prop: ElementProp, value: f32) -> StyleEf
         ElementProp::Disabled
         | ElementProp::Multiline
         | ElementProp::Secure
-        | ElementProp::Checked => {
+        | ElementProp::Checked
+        | ElementProp::Focusable => {
             return set_element_bool(node, prop, value > 0.5);
         }
         _ => {}
@@ -214,6 +216,12 @@ fn set_element_bool(node: &mut Node, prop: ElementProp, value: bool) -> StyleEff
         ElementProp::Checked => {
             if let Some(checked) = node.as_checkbox_input_mut() {
                 *checked = value;
+                return StyleEffect::Applied;
+            }
+        }
+        ElementProp::Focusable => {
+            if let Some(element) = node.as_element_mut() {
+                element.set_focussable(value);
                 return StyleEffect::Applied;
             }
         }
@@ -266,6 +274,12 @@ fn clear_element_prop(node: &mut Node, prop: ElementProp) -> StyleEffect {
                 return StyleEffect::Applied;
             }
         }
+        ElementProp::Focusable => {
+            if let Some(element) = node.as_element_mut() {
+                element.set_focussable(false);
+                return StyleEffect::Applied;
+            }
+        }
     }
     StyleEffect::Ignored
 }
@@ -299,6 +313,10 @@ fn get_element_prop(node: &Node, prop: ElementProp) -> Value {
         ElementProp::Checked => node
             .as_checkbox_input()
             .map(|v| json!(v))
+            .unwrap_or(Value::Null),
+        ElementProp::Focusable => node
+            .as_element()
+            .map(|v| json!(v.is_focussable()))
             .unwrap_or(Value::Null),
     }
 }

--- a/crates/uzumaki/src/prop_keys.rs
+++ b/crates/uzumaki/src/prop_keys.rs
@@ -84,6 +84,7 @@ pub(crate) enum ElementProp {
     Multiline,
     Secure,
     Checked,
+    Focusable,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -207,6 +208,7 @@ impl FromStr for ElementProp {
             "multiline" => Self::Multiline,
             "secure" => Self::Secure,
             "checked" => Self::Checked,
+            "focusable" => Self::Focusable,
             _ => return Err(()),
         })
     }


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->

## Checklist

- [ ] I have run `cargo fmt` and `pnpm format`
- [ ] I have run `cargo clippy --workspace -D warnings` and `pnpm lint` with no errors
- [ ] I have manually tested my changes
- [ ] This PR is focused on a single scope — no unrelated drive-by changes
- [ ] If this PR uses AI-generated code, I have thoroughly reviewed and tested every line myself
