### PR TITLE
fix: scroll property

### DIFF
--- a/crates/uzumaki/src/ops/style_util.rs
+++ b/crates/uzumaki/src/ops/style_util.rs
@@ -677,22 +677,24 @@ fn set_variant_number(
     let r = get_or_init_variant_style(node, variant);
     match prop {
         StyleProp::Scroll => {
-            r.overflow_y = Some(if value > 0.5 {
-                Overflow::Scroll
+            let overflow = if value > 0.5 {
+                Overflow::Auto
             } else {
                 Overflow::Visible
-            });
+            };
+            r.overflow_x = Some(overflow);
+            r.overflow_y = Some(overflow);
         }
         StyleProp::ScrollX => {
             r.overflow_x = Some(if value > 0.5 {
-                Overflow::Scroll
+                Overflow::Auto
             } else {
                 Overflow::Visible
             });
         }
         StyleProp::ScrollY => {
             r.overflow_y = Some(if value > 0.5 {
-                Overflow::Scroll
+                Overflow::Auto
             } else {
                 Overflow::Visible
             });
@@ -975,7 +977,10 @@ fn clear_variant_prop(node: &mut Node, prop: StyleProp, variant: StyleVariant) -
             StyleProp::Cursor => style.cursor = None,
             StyleProp::Interactive => {}
             StyleProp::Visibility => style.visibility = None,
-            StyleProp::Scroll => style.overflow_y = None,
+            StyleProp::Scroll => {
+                style.overflow_x = None;
+                style.overflow_y = None;
+            }
             StyleProp::ScrollX => style.overflow_x = None,
             StyleProp::ScrollY => style.overflow_y = None,
             StyleProp::TextSelect => style.text_selectable = None,
@@ -1116,29 +1121,43 @@ fn set_f32_style_prop(node: &mut Node, prop: StyleProp, v: f32) -> StyleEffect {
             node.interactivity.js_interactive = v > 0.5;
             return StyleEffect::Applied;
         }
-        StyleProp::Scroll | StyleProp::ScrollY => {
+        StyleProp::Scroll => {
             if v > 0.5 {
-                node.style.overflow_y = Overflow::Scroll;
+                node.style.overflow_x = Overflow::Auto;
+                node.style.overflow_y = Overflow::Auto;
                 if node.scroll_state.is_none() {
                     node.scroll_state = Some(element::ScrollState::new());
                 }
             } else {
+                node.style.overflow_x = Overflow::Visible;
                 node.style.overflow_y = Overflow::Visible;
-                if node.style.overflow_x == Overflow::Visible {
-                    node.scroll_state = None;
-                }
+                node.scroll_state = None;
             }
             return StyleEffect::AppliedNeedsSync;
         }
         StyleProp::ScrollX => {
             if v > 0.5 {
-                node.style.overflow_x = Overflow::Scroll;
+                node.style.overflow_x = Overflow::Auto;
                 if node.scroll_state.is_none() {
                     node.scroll_state = Some(element::ScrollState::new());
                 }
             } else {
                 node.style.overflow_x = Overflow::Visible;
                 if node.style.overflow_y == Overflow::Visible {
+                    node.scroll_state = None;
+                }
+            }
+            return StyleEffect::AppliedNeedsSync;
+        }
+        StyleProp::ScrollY => {
+            if v > 0.5 {
+                node.style.overflow_y = Overflow::Auto;
+                if node.scroll_state.is_none() {
+                    node.scroll_state = Some(element::ScrollState::new());
+                }
+            } else {
+                node.style.overflow_y = Overflow::Visible;
+                if node.style.overflow_x == Overflow::Visible {
                     node.scroll_state = None;
                 }
             }
@@ -1443,15 +1462,20 @@ fn clear_style_prop(node: &mut Node, prop: StyleProp, variant: StyleVariant) -> 
         StyleProp::Cursor => node.style.cursor = default.cursor,
         StyleProp::Interactive => node.interactivity.js_interactive = false,
         StyleProp::Visibility => node.style.visibility = default.visibility,
-        StyleProp::Scroll | StyleProp::ScrollY => {
+        StyleProp::Scroll => {
+            node.style.overflow_x = default.overflow_x;
             node.style.overflow_y = default.overflow_y;
-            if node.style.overflow_x == Overflow::Visible {
-                node.scroll_state = None;
-            }
+            node.scroll_state = None;
         }
         StyleProp::ScrollX => {
             node.style.overflow_x = default.overflow_x;
             if node.style.overflow_y == Overflow::Visible {
+                node.scroll_state = None;
+            }
+        }
+        StyleProp::ScrollY => {
+            node.style.overflow_y = default.overflow_y;
+            if node.style.overflow_x == Overflow::Visible {
                 node.scroll_state = None;
             }
         }
@@ -1510,9 +1534,12 @@ fn get_style_prop(node: &Node, prop: StyleProp) -> Value {
             .unwrap_or(Value::Null),
         StyleProp::Opacity => json!(style.opacity),
         StyleProp::Visibility => json!(matches!(style.visibility, Visibility::Visible)),
-        StyleProp::Scroll => json!(matches!(style.overflow_y, Overflow::Scroll)),
-        StyleProp::ScrollX => json!(matches!(style.overflow_x, Overflow::Scroll)),
-        StyleProp::ScrollY => json!(matches!(style.overflow_y, Overflow::Scroll)),
+        StyleProp::Scroll => json!(
+            matches!(style.overflow_x, Overflow::Auto)
+                && matches!(style.overflow_y, Overflow::Auto)
+        ),
+        StyleProp::ScrollX => json!(matches!(style.overflow_x, Overflow::Auto)),
+        StyleProp::ScrollY => json!(matches!(style.overflow_y, Overflow::Auto)),
         StyleProp::TextSelect => json!(node.is_text_selectable()),
         StyleProp::Top => length_to_json(style.inset.top),
         StyleProp::Right => length_to_json(style.inset.right),
@@ -1596,8 +1623,9 @@ fn font_weight_to_number(weight: FontWeight) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::{
-        Display, FlexDirection, FontWeight, Node, StyleVariant, UzStyle, parse_font_weight_number,
-        parse_font_weight_str, set_flex_string, set_variant_flex_string,
+        Display, FlexDirection, FontWeight, Node, Overflow, StyleVariant, UzStyle,
+        parse_font_weight_number, parse_font_weight_str, set_f32_style_prop, set_flex_string,
+        set_variant_flex_string, set_variant_number,
     };
 
     #[test]
@@ -1653,5 +1681,42 @@ mod tests {
         let hover = node.interactivity.hover_style.as_ref().unwrap();
         assert_eq!(hover.display, Some(Display::Flex));
         assert_eq!(hover.flex_direction, Some(FlexDirection::Column));
+    }
+
+    #[test]
+    fn scroll_sets_both_axes_to_auto() {
+        let mut node = Node::new(
+            taffy::NodeId::from(0usize),
+            UzStyle::default(),
+            crate::element::ElementNode::new(crate::element::ElementData::None),
+        );
+
+        let effect = set_f32_style_prop(&mut node, super::StyleProp::Scroll, 1.0);
+
+        assert!(matches!(effect, super::StyleEffect::AppliedNeedsSync));
+        assert_eq!(node.style.overflow_x, Overflow::Auto);
+        assert_eq!(node.style.overflow_y, Overflow::Auto);
+        assert!(node.scroll_state.is_some());
+    }
+
+    #[test]
+    fn variant_scroll_sets_both_axes_to_auto() {
+        let mut node = Node::new(
+            taffy::NodeId::from(0usize),
+            UzStyle::default(),
+            crate::element::ElementNode::new(crate::element::ElementData::None),
+        );
+
+        let effect = set_variant_number(
+            &mut node,
+            super::StyleProp::Scroll,
+            StyleVariant::Hover,
+            1.0,
+        );
+
+        assert!(matches!(effect, super::StyleEffect::Applied));
+        let hover = node.interactivity.hover_style.as_ref().unwrap();
+        assert_eq!(hover.overflow_x, Some(Overflow::Auto));
+        assert_eq!(hover.overflow_y, Some(Overflow::Auto));
     }
 }

--- a/packages/playground/src/pages/issuesPage.tsx
+++ b/packages/playground/src/pages/issuesPage.tsx
@@ -140,8 +140,7 @@ export function IssuesPage() {
             </view>
             <view
               h={420}
-              scrollX
-              scrollY
+              scroll
               bg={C.surface}
               rounded={8}
               border={1}

--- a/packages/playground/src/pages/layoutPage.tsx
+++ b/packages/playground/src/pages/layoutPage.tsx
@@ -947,8 +947,8 @@ function ScrollDemo() {
           Scroll props
         </text>
         <text fontSize={12} color={C.textMuted}>
-          `scroll` enables vertical overflow, `scrollX` enables horizontal
-          overflow, and you can combine `scrollX` with `scrollY` for both axes.
+          `scroll` enables auto overflow on both axes, while `scrollX` and
+          `scrollY` let you opt into each axis separately.
         </text>
       </view>
 
@@ -969,22 +969,28 @@ function ScrollDemo() {
             flexDir="col"
             gap={8}
           >
-            {Array.from({ length: 24 }, (_, i) => (
-              <view
-                key={i}
-                p={10}
-                bg={i % 2 === 0 ? C.surface3 : C.surface4}
-                rounded={6}
-                display="flex"
-                items="center"
-                justify="between"
-              >
-                <text fontSize={12} fontWeight={600} color={C.text}>
-                  Row #{i + 1}
-                </text>
-                <text fontSize={11} color={C.textMuted}>
-                  vertical content
-                </text>
+            {Array.from({ length: 12 }, (_, i) => (
+              <view key={i} display="flex" flexDir="row" gap={10}>
+                {Array.from({ length: 6 }, (_, j) => (
+                  <view
+                    key={`${i}-${j}`}
+                    w={140}
+                    flexShrink={0}
+                    p={10}
+                    bg={(i + j) % 2 === 0 ? C.surface3 : C.surface4}
+                    rounded={6}
+                    display="flex"
+                    items="center"
+                    justify="between"
+                  >
+                    <text fontSize={12} fontWeight={600} color={C.text}>
+                      Row {i + 1}
+                    </text>
+                    <text fontSize={11} color={C.textMuted}>
+                      Col {j + 1}
+                    </text>
+                  </view>
+                ))}
               </view>
             ))}
           </view>
@@ -1031,45 +1037,38 @@ function ScrollDemo() {
 
         <view display="flex" flexDir="col" gap={8}>
           <text fontSize={12} fontWeight={600} color={C.textMuted}>
-            scrollX + scrollY
+            scrollY
           </text>
           <view
             h={220}
-            scrollX
             scrollY
             bg={C.surface2}
             rounded={8}
             border={1}
             borderColor={C.border}
             p={12}
+            display="flex"
+            flexDir="col"
+            gap={10}
           >
-            <view display="flex" flexDir="col" gap={10}>
-              {Array.from({ length: 8 }, (_, row) => (
-                <view key={row} display="flex" flexDir="row" gap={10}>
-                  {Array.from({ length: 8 }, (_, col) => (
-                    <view
-                      key={`${row}-${col}`}
-                      w={120}
-                      h={72}
-                      flexShrink={0}
-                      rounded={8}
-                      p={10}
-                      bg={(row + col) % 2 === 0 ? C.successDim : C.warningDim}
-                      display="flex"
-                      flexDir="col"
-                      justify="between"
-                    >
-                      <text fontSize={12} fontWeight={700} color={C.text}>
-                        Cell {row + 1},{col + 1}
-                      </text>
-                      <text fontSize={10} color={C.textMuted}>
-                        Both axes can scroll
-                      </text>
-                    </view>
-                  ))}
-                </view>
-              ))}
-            </view>
+            {Array.from({ length: 14 }, (_, i) => (
+              <view
+                key={i}
+                p={12}
+                bg={i % 2 === 0 ? C.successDim : C.warningDim}
+                rounded={8}
+                display="flex"
+                flexDir="col"
+                gap={4}
+              >
+                <text fontSize={12} fontWeight={700} color={C.text}>
+                  Log entry #{i + 1}
+                </text>
+                <text fontSize={10} color={C.textMuted}>
+                  Vertical overflow only
+                </text>
+              </view>
+            ))}
           </view>
         </view>
       </view>


### PR DESCRIPTION
`scroll` enables auto overflow on both axes, while `scrollX` and

`scrollY` let you opt into each axis separately.



