### PR TITLE
fix(events): fix nested button click behavior and restrict keyboard i…

### DIFF
--- a/crates/uzumaki/js/dispatcher.ts
+++ b/crates/uzumaki/js/dispatcher.ts
@@ -10,9 +10,50 @@ import {
   type EventName,
   type UzumakiEvent,
 } from './events';
+import { UzNode } from './node';
 import { getNode } from './registry';
 import type { NodeId } from './types';
 import type { Window } from './window';
+
+function canInteract(
+  node: UzNode | null,
+  action: 'click' | 'keyboard' | 'focus',
+): boolean {
+  if (!node?.interactionType) return false;
+
+  switch (node.interactionType) {
+    case 'button':
+      return action === 'click' || action === 'keyboard';
+
+    case 'input':
+      return action === 'focus' || action === 'keyboard' || action === 'click';
+
+    case 'text':
+    case 'container':
+    default:
+      return false;
+  }
+}
+
+function resolveInteractiveTarget(
+  windowId: number,
+  nodeId: NodeId | null,
+): NodeId | null {
+  if (nodeId == null) return null;
+
+  const path = core.getAncestorPath(windowId, nodeId);
+
+  for (let i = path.length - 1; i >= 0; i--) {
+    const id = path[i]!;
+    const node = getNode(windowId, id);
+
+    if (node?.interactionType === 'button') {
+      return id;
+    }
+  }
+
+  return nodeId;
+}
 
 function nodeAt(windowId: number, id: NodeId | null) {
   if (id == null) return null;
@@ -71,11 +112,27 @@ export function dispatchDomEvent(
   const name = EVENT_TYPE_TO_NAME[type];
   if (!name) return false;
 
-  const target = nodeAt(window.id, targetNodeId);
+  const resolvedTargetNodeId = resolveInteractiveTarget(
+    window.id,
+    targetNodeId,
+  );
+
+  const target = nodeAt(window.id, resolvedTargetNodeId);
+  if (type === EventType.Click) {
+    if (!canInteract(target, 'click')) {
+      return false;
+    }
+  }
+
+  if (type === EventType.KeyDown || type === EventType.KeyUp) {
+    if (!canInteract(target, 'keyboard')) {
+      return false;
+    }
+  }
   return dispatchEvent(
     window,
     name,
-    targetNodeId,
+    resolvedTargetNodeId,
     buildDomEvent(type, target, payload),
   );
 }

--- a/crates/uzumaki/js/index.ts
+++ b/crates/uzumaki/js/index.ts
@@ -1,6 +1,7 @@
 import core from './core';
 import { dispatchDomEvent } from './dispatcher';
 import { EventType } from './events';
+import { getNode } from './registry';
 import { disposeWindow, Window } from './window';
 
 export { Window } from './window';

--- a/crates/uzumaki/js/node.ts
+++ b/crates/uzumaki/js/node.ts
@@ -7,10 +7,12 @@ import type { Window } from './window';
 export class UzNode {
   readonly _native: CoreNode;
   readonly _window: Window;
+  interactionType?: 'button' | 'input' | 'container' | 'text';
 
   constructor(window: Window, native: CoreNode) {
     this._window = window;
     this._native = native;
+    this.interactionType = inferInteractionType(native.nodeName);
     registerNode(this);
   }
 
@@ -98,5 +100,26 @@ export class UzNode {
 export class UzTextNode extends UzNode {
   constructor(window: Window, text: string) {
     super(window, core.createTextNode(window.id, text));
+  }
+}
+
+function inferInteractionType(
+  nodeName: string,
+): 'button' | 'input' | 'container' | 'text' {
+  switch (nodeName.toLowerCase()) {
+    case 'button':
+      return 'button';
+
+    case 'input':
+    case 'textarea':
+      return 'input';
+
+    case 'span':
+    case 'p':
+    case 'text':
+      return 'text';
+
+    default:
+      return 'container';
   }
 }


### PR DESCRIPTION
…nteraction by element type

## Description
This PR fixes incorrect interaction behavior in the UI event system and introduces element-type aware interaction rules.

<!-- What does this PR do and why? -->
**PROBLEM**
Clicking text or child nodes inside a button did not trigger active/pressed state
Button interactions only worked when clicking the root button element directly
Keyboard interactions (Enter/Space) were inconsistently applied to all focused nodes
No clear separation between interactive element types (button, input, container, etc.)

**CHANGES**
Implemented resolveInteractiveTarget to ensure events bubble from child nodes to the correct interactive parent (e.g. button)
Introduced interactionType on nodes to classify elements (button, input, text, container)
Added canInteract() to enforce element-specific interaction rules
Restricted keyboard activation (Enter/Space) to button-like elements only
Improved consistency between click and keyboard interaction handling

**RESULT**
Clicking anywhere inside a button (including text/child nodes) now correctly triggers active state
Keyboard interactions are properly scoped to element types
Interaction system now behaves closer to native DOM semantics
## Checklist

- [X] I have run `cargo fmt` and `pnpm format`
- [X] I have run `cargo clippy --workspace -D warnings` and `pnpm lint` with no errors
- [X] I have manually tested my changes
- [X] This PR is focused on a single scope — no unrelated drive-by changes
- [X] If this PR uses AI-generated code, I have thoroughly reviewed and tested every line myself
