### PR TITLE
fix: enter tokio runtime before worker bootstrap

### DIFF
--- a/crates/uzumaki/src/app.rs
+++ b/crates/uzumaki/src/app.rs
@@ -307,7 +307,10 @@ impl Application {
             ..Default::default()
         };
 
-        let mut worker = MainWorker::bootstrap_from_options(&main_module, services, options);
+        let mut worker = {
+            let _guard = tokio_runtime.enter();
+            MainWorker::bootstrap_from_options(&main_module, services, options)
+        };
 
         let global_app_event_dispatch_fn = {
             let context = worker.js_runtime.main_context();


### PR DESCRIPTION
## Description

Enters Tokio runtime context before calling MainWorker::bootstrap_from_options(...) in Application::new_with_root

Closes #90 
## Checklist

- [x] I have run `cargo fmt` and `pnpm format`
- [x] I have run `cargo clippy --workspace -D warnings` and `pnpm lint` with no errors
- [x] I have manually tested my changes
- [x] This PR is focused on a single scope — no unrelated drive-by changes
- [ ] If this PR uses AI-generated code, I have thoroughly reviewed and tested every line myself
